### PR TITLE
faster, better exists() method

### DIFF
--- a/zsh/.zsh_functions
+++ b/zsh/.zsh_functions
@@ -7,7 +7,7 @@
 # BSD licensed, see LICENSE.txt
 
 function exists() {
-  which $1 &> /dev/null
+  if (( $+commands[$1] )); then return 0; else return 1; fi
 }
 
 # from cads@ooyala.com


### PR DESCRIPTION
Uses zsh native methods to see if a command exists.  This will not show any aliases or functions, however.