### PR TITLE
Use /bin/ls instead of whatever ls got aliased to

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -210,7 +210,8 @@ fi
 # Make it easy to append your own customizations that override the above by
 # loading all files from .zshrc.d directory
 mkdir -p ~/.zshrc.d
-if [ -n "$(ls ~/.zshrc.d)" ]; then
+
+if [ -n "$(/bin/ls ~/.zshrc.d)" ]; then
   for dotfile in ~/.zshrc.d/*
   do
     if [ -r "${dotfile}" ]; then


### PR DESCRIPTION
If a plugin aliased ls and ls fails, your customizations would't load.