### PR TITLE
Add cargo's bindir to path candidates

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -29,6 +29,7 @@ for path_candidate in /opt/local/sbin \
   /opt/local/bin \
   /usr/local/share/npm/bin \
   ~/.cabal/bin \
+  ~/.cargo/bin \
   ~/.rbenv/bin \
   ~/bin \
   ~/src/gocode/bin


### PR DESCRIPTION
Rust's cargo build tool installs to `~/.cargo/bin` by default; make sure
that is in the user's `$PATH` if present.