### PR TITLE
Add template .zgen-local-plugins file

### DIFF
--- a/.zgen-local-plugins-example
+++ b/.zgen-local-plugins-example
@@ -1,0 +1,123 @@
+#!/bin/zsh
+#
+# Only including a shebang to trigger Sublime Text to use shell syntax highlighting
+#
+# Copyright 2006-2017 Joseph Block <jpb@unixorn.net>
+#
+# The Zsh Starter Kit allows you to replace the curated plugins list it
+# ships with with a custom one by creating a file named .zgen-local-plugins.
+#
+# This is to make it easier to customize without having to maintain a separate
+# fork of the starter kit.
+#
+# This example file duplicates the list of plugins that shipped with the
+# kit as of 2017-05-07.
+
+ZGEN_LOADED=()
+ZGEN_COMPLETIONS=()
+
+zgen oh-my-zsh
+
+# If you want to customize your plugin list, create a file named
+# .zgen-local-plugins in your home directory. That file will be sourced
+# during startup *instead* of running this load-starter-plugin-list function,
+# so make sure to include everything from this function that you want to keep.
+
+# If zsh-syntax-highlighting is bundled after zsh-history-substring-search,
+# they break, so get the order right.
+zgen load zsh-users/zsh-syntax-highlighting
+zgen load zsh-users/zsh-history-substring-search
+
+# Set keystrokes for substring searching
+zmodload zsh/terminfo
+bindkey "$terminfo[kcuu1]" history-substring-search-up
+bindkey "$terminfo[kcud1]" history-substring-search-down
+
+# Tab complete rakefile targets
+zgen load unixorn/rake-completion.zshplugin
+
+# Automatically run zgen update and zgen selfupdate every 7 days
+zgen load unixorn/autoupdate-zgen
+
+# Add my random utility functions
+zgen load unixorn/jpb.zshplugin
+
+# Colorize the things if you have grc installed. Well, some of the
+# things, anyway.
+zgen load unixorn/warhol.plugin.zsh
+
+# OS X helpers. This plugin is smart enough to detect when it isn't running
+# on OS X and not load itself, so you can safely share the same plugin list
+# across OS X and Linux/BSD
+zgen load unixorn/tumult.plugin.zsh
+
+# Warn you when you run a command that you've set an alias for
+zgen load djui/alias-tips
+
+# Add my collection of git helper scripts
+zgen load unixorn/git-extra-commands
+
+# Add my bitbucket git helpers plugin
+zgen load unixorn/bitbucket-git-helpers.plugin.zsh
+
+# A collection of scripts that might be useful to sysadmins
+zgen load skx/sysadmin-util
+
+# Adds aliases to open your current repo & branch on github.
+zgen load peterhurford/git-it-on.zsh
+
+# Tom Limoncelli's tooling for storing private information (keys, etc)
+# in a repository securely by encrypting them with gnupg
+zgen load StackExchange/blackbox
+
+# Load some oh-my-zsh plugins
+zgen oh-my-zsh plugins/pip
+zgen oh-my-zsh plugins/sudo
+zgen oh-my-zsh plugins/aws
+zgen oh-my-zsh plugins/chruby
+zgen oh-my-zsh plugins/colored-man-pages
+zgen oh-my-zsh plugins/git
+zgen oh-my-zsh plugins/github
+zgen oh-my-zsh plugins/python
+zgen oh-my-zsh plugins/rsync
+zgen oh-my-zsh plugins/screen
+zgen oh-my-zsh plugins/vagrant
+
+if [ $(uname -a | grep -ci Darwin) = 1 ]; then
+  # Load OSX-specific plugins
+  zgen oh-my-zsh plugins/brew
+  zgen oh-my-zsh plugins/osx
+fi
+
+# A set of shell functions to make it easy to install small apps and
+# utilities distributed with pip.
+zgen load sharat87/pip-app
+
+zgen load chrissicool/zsh-256color
+
+# Load more completion files for zsh from the zsh-lovers github repo
+zgen load zsh-users/zsh-completions src
+
+# Docker completion
+zgen load srijanshetty/docker-zsh
+
+# Load me last
+GENCOMPL_FPATH=$HOME/.zsh/complete
+
+# Very cool plugin that generates zsh completion functions for commands
+# if they have getopt-style help text. It doesn't generate them on the fly,
+# you'll have to explicitly generate a completion, but it's still quite cool.
+zgen load RobSis/zsh-completion-generator
+
+# Add Fish-like autosuggestions to your ZSH
+zgen load zsh-users/zsh-autosuggestions
+
+# k is a zsh script / plugin to make directory listings more readable,
+# adding a bit of color and some git status information on files and directories
+zgen load rimraf/k
+
+# Bullet train prompt setup
+zgen load caiogondim/bullet-train-oh-my-zsh-theme bullet-train
+
+# Save it all to init script
+zgen save

--- a/Readme.md
+++ b/Readme.md
@@ -117,9 +117,13 @@ The quickstart kit will check for updates every seven days. If you want to chang
 
 ### Changing the zgen plugin list
 
-I've included what I think is a good starter set of zsh plugins in this repository. To make the list easier to customize without having to maintain a separate fork of this kit, if you create a file named `~/.zgen-local-plugins`, the `.zshrc` from this starter kit will source that **instead** of running the `load-starter-plugin-list` function defined in `~/.zgen-setup`.
+I've included what I think is a good starter set of zsh plugins in this repository. However, everyone has their own preferences for their environment, so to make the list easier to customize without having to maintain a separate fork of this kit, if you create a file named `~/.zgen-local-plugins`, the `.zshrc` from this starter kit will source that **instead** of running the `load-starter-plugin-list` function defined in `~/.zgen-setup`.
 
 **Note: using `~/.zgen-local-plugins` is not additive, it will completely replace the kit-provided list.**
+
+I'm told it's a pain to have to create `.zgen-local-plugins` from scratch, so to make customizing the plugins easier, I've included a `.zgen-local-plugins-example` file at the root of the repository that will install the same plugins that the kit does by default for you to use as a starting point for your own customizations.
+
+Copy that to your `$HOME`, change the list and the next time you start a terminal session you'll get your list instead of mine.
 
 ### Included plugins:
 

--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -1,8 +1,9 @@
 #!/bin/zsh
 #
-# Only including a shebang to trigger Sublime Text to use shell syntax highlighting
+# Only including a shebang to trigger Sublime Text to use shell
+# syntax highlighting.
 #
-# Copyright 2006-2016 Joseph Block <jpb@unixorn.net>
+# Copyright 2006-2017 Joseph Block <jpb@unixorn.net>
 #
 # BSD licensed, see LICENSE.txt
 
@@ -49,16 +50,19 @@ load-starter-plugin-list() {
   # Automatically run zgen update and zgen selfupdate every 7 days
   zgen load unixorn/autoupdate-zgen
 
+  # Add my collection of miscellaneous utility functions.
   zgen load unixorn/jpb.zshplugin
 
   # Colorize the things if you have grc installed. Well, some of the
   # things, anyway.
   zgen load unixorn/warhol.plugin.zsh
 
-  # OS X helpers
+  # OS X helpers. This plugin is smart enough to detect when it isn't running
+  # on OS X and not load itself, so you can safely share the same plugin list
+  # across OS X and Linux/BSD
   zgen load unixorn/tumult.plugin.zsh
 
-  # Warn you when you run a command that you've got an alias for
+  # Warn you when you run a command that you've set an alias for
   zgen load djui/alias-tips
 
   # Add my collection of git helper scripts


### PR DESCRIPTION
Make it easier for people to start customizations by giving them a `.zgen-local-plugins` file that installs everything the kit does by default. They can change it to meet their needs without having to start from scratch.