### PR TITLE
Ignore unordered list complaints in markdown check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -21,6 +21,8 @@ engines:
   markdownlint:
     enabled: true
     checks:
+      MD004:
+        enabled: false
       MD013:
         enabled: false
       MD026:


### PR DESCRIPTION
Code Climate doesn't like our unordered list entries; disable that check