### PR TITLE
Minor text cleanups

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,7 @@
   - [Set up Zgen and the starter kit](#set-up-zgen-and-the-starter-kit)
   - [Customizations](#customizations)
     - [Functions and Aliases](#functions-and-aliases)
+    - [ZSH options.](#zsh-options)
     - [Self-update Settings](#self-update-settings)
     - [Changing the zgen plugin list](#changing-the-zgen-plugin-list)
     - [Included plugins:](#included-plugins)

--- a/Readme.md
+++ b/Readme.md
@@ -101,21 +101,25 @@ Now that your fonts and default shell have been set up, install [zgen](https://g
 
 The `.zshrc`, `.zsh_aliases` & `.zsh_functions` files included in this kit enable:
 
-* Automatic periodic updates to **zgen** and your plugins
+* Automatic periodic updates of both zgen and your plugins
 * Cross-session shared history so commands typed in one terminal window can be seen and searched in all other windows on the same machine.
 * Deduping your command history
-* Many more tab completions, courtesy of the [zsh-users/zsh-completions](https://github.com/zsh-users/zsh-completions) repository, and periodic updating to tip of master of that repository so you get new completions and updates of old ones.
+* Many more tab completions, courtesy of the [zsh-users/zsh-completions](https://github.com/zsh-users/zsh-completions) repository, and periodic updating to tip of master of that repository so you get updates to the extra tab completions.
 * Proper command history search
 * Syntax highlighting at the command line
 * Tab completion of Rakefile targets
-* Using oh-my-zsh compatible plugins and themes (via the [zgen](https://github.com/tarjoilija/zgen) framework)
-* Various helper functions for interacting with macOS's clipboard, audio volume, Spotlight and Quicklook.
+* Using [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)-compatible plugins and themes (via the [zgen](https://github.com/tarjoilija/zgen) framework)
+* Various helper functions for interacting with macOS's clipboard, audio volume, Spotlight and Quicklook. These will only load if you are on a macOS machine.
 
 ## Customizations
 
 ### Functions and Aliases
 
 The `.zshrc` included in this kit will automatically source any files it finds in `~/.zshrc.d`. This is to make it easy for you to add extra functions and aliases without having to maintain a separate fork of this repository. The files will be sourced in alphanumeric order and I suggest you use a naming scheme of `001-onething`, `002-something-else` etc to ensure they're loaded in the order you expect.
+
+### ZSH options.
+
+The quickstart kit does an opinionated (i.e. my way) setup of ZSH options and adds some functions and aliases I like on my systems. However, `~/.zshrc.d` is processed after the quickstart sets its aliases, functions and ZSH options, so if you don't care for something set up in the quickstart, you can override the offending item in a shell fragment file there.
 
 ### Self-update Settings
 
@@ -125,9 +129,9 @@ The quickstart kit will check for updates every seven days. If you want to chang
 
 I've included what I think is a good starter set of zsh plugins in this repository. However, everyone has their own preferences for their environment. To make the list easier to customize without having to maintain a separate fork of this kit, if you create a file named `~/.zgen-local-plugins`, the `.zshrc` from this starter kit will source that **instead** of running the `load-starter-plugin-list` function defined in `~/.zgen-setup`.
 
-**Note: using `~/.zgen-local-plugins` is not additive, it will completely replace the kit-provided list.**
+**Note: using `~/.zgen-local-plugins` is not additive, it will _completely replace_ the kit-provided list of plugins.**
 
-I'm told it's a pain to have to create `.zgen-local-plugins` from scratch, so to make customizing the plugins easier, I've included a `.zgen-local-plugins-example` file at the root of the repository that will install the same plugins that the kit does by default for you to use as a starting point for your own customizations.
+It's a pain to have to create `.zgen-local-plugins` from scratch, so to make customizing your plugins easier, I've included a `.zgen-local-plugins-example` file at the root of the repository that will install the same plugin list that the kit does by default that you can use as a starting point for your own customizations.
 
 Copy that to your `$HOME/.zgen-local-plugins`, change the list and the next time you start a terminal session you'll get your list instead of mine.
 
@@ -142,7 +146,7 @@ Copy that to your `$HOME/.zgen-local-plugins`, change the list and the next time
 * [srijanshetty/docker-zsh](https://github.com/srijanshetty/docker-zsh) - Docker completions.
 * [stackexchange/blackbox](https://github.com/stackexchange/blackbox) - Tom Limoncelli's tool for storing secret information in a repository with gnupg encryption, automatically decrypting as needed.
 * [supercrabtree/k](https://github.com/supercrabtree/k) - k is a directory lister that also shows git status on files & directories.
-* [unixorn/autoupdate-zgen](https://github.com/unixorn/autoupdate-zgen) - Adds autoupdate (for both zgen itself, and your plugins) to zgen.
+* [unixorn/autoupdate-zgen](https://github.com/unixorn/autoupdate-zgen) - Adds autoupdate (for both `zgen` itself, and your plugins) to `zgen`.
 * [unixorn/bitbucket-git-helpers](https://github.com/unixorn/bitbucket-git-helpers.plugin.zsh) - Adds git helper scripts for bitbucket.
 * [unixorn/git-extra-commands](https://github.com/unixorn/git-extra-commands) - Collected helper scripts for `git`.
 * [unixorn/jpb.zshplugin](https://github.com/unixorn/jpb.zshplugin) - Some of my standard aliases & functions.
@@ -172,7 +176,7 @@ The quickstart kit also uses zgen to load oh-my-zsh and these plugins:
 
 ## ZSH
 
-For a list of other ZSH plugins and themes you might like to use, check out my [awesome-zsh-plugins](https://github.com/unixorn/awesome-zsh-plugins) list.
+For a list of other ZSH plugins, completions and themes you might like to use, check out my [awesome-zsh-plugins](https://github.com/unixorn/awesome-zsh-plugins) list.
 
 ## Dotfiles in general
 

--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -3,7 +3,7 @@
 # Only including a shebang to trigger Sublime Text to use shell
 # syntax highlighting.
 #
-# Copyright 2006-2017 Joseph Block <jpb@unixorn.net>
+# Copyright 2006-2018 Joseph Block <jpb@unixorn.net>
 #
 # BSD licensed, see LICENSE.txt
 

--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -95,7 +95,7 @@ load-starter-plugin-list() {
   zgen oh-my-zsh plugins/vagrant
 
   if [ $(uname -a | grep -ci Darwin) = 1 ]; then
-    # Load OSX-specific plugins
+    # Load macOS-specific plugins
     zgen oh-my-zsh plugins/brew
     zgen oh-my-zsh plugins/osx
   fi
@@ -143,12 +143,12 @@ setup-zgen-repos() {
 }
 
 # This comes from https://stackoverflow.com/questions/17878684/best-way-to-get-file-modified-time-in-seconds
-# This works on both Linux with GNU fileutils and OS X with BSD stat.
+# This works on both Linux with GNU fileutils and macOS with BSD stat.
 
-# Naturally BSD/OS X and Linux can't share the same options to stat.
+# Naturally BSD/macOS and Linux can't share the same options to stat.
 if [[ $(uname | grep -ci -e Darwin -e BSD) = 1 ]]; then
 
-  # OS X version
+  # macOS version
   get_file_modification_time() {
     modified_time=$(stat -f %m "$1" 2> /dev/null) || modified_time=0
     echo "${modified_time}"

--- a/zsh/.zsh_aliases
+++ b/zsh/.zsh_aliases
@@ -2,7 +2,7 @@
 #
 # Only including a shebang to trigger Sublime Text to use shell syntax highlighting
 #
-# Copyright 2006-2016 Joseph Block <jpb@unixorn.net>
+# Copyright 2006-2018 Joseph Block <jpb@unixorn.net>
 #
 # BSD licensed, see LICENSE.txt
 
@@ -20,7 +20,6 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   # do OS X specific things
 
   alias top="TERM=vt100 top"
-
 else
   alias cputop="top -o cpu"
   alias l-d="ls -lad"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -211,13 +211,12 @@ echo
 # Honor old .zshrc.local customizations, but print deprecation warning.
 if [ -f ~/.zshrc.local ]; then
   source ~/.zshrc.local
-  echo ".zshrc.local is deprecated - use files in ~/.zshrc.d instead"
+  echo '~/.zshrc.local is deprecated - use files in ~/.zshrc.d instead. Future versions of zsh-quickstart-kits will no longer load it'
 fi
 
 # Make it easy to append your own customizations that override the above by
-# loading all files from .zshrc.d directory
+# loading all files from the ~/.zshrc.d directory
 mkdir -p ~/.zshrc.d
-
 if [ -n "$(/bin/ls ~/.zshrc.d)" ]; then
   for dotfile in ~/.zshrc.d/*
   do
@@ -232,7 +231,6 @@ fi
 #
 # This snippet is from Mislav Marohnić <mislav.marohnic@gmail.com>'s
 # dotfiles repo at https://github.com/mislav/dotfiles
-
 dedupe_path() {
   typeset -a paths result
   paths=($path)
@@ -291,7 +289,6 @@ _update-zsh-quickstart() {
     popd
   fi
 }
-
 
 _check-for-zsh-quickstart-update() {
   local day_seconds=$(expr 24 \* 60 \* 60)

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,4 +1,4 @@
-# Copyright 2006-2017 Joseph Block <jpb@apesseekingknowledge.net>
+# Copyright 2006-2018 Joseph Block <jpb@apesseekingknowledge.net>
 #
 # BSD licensed, see LICENSE.txt
 


### PR DESCRIPTION
* Updated copyright notices
* OS X is now called macOS, fix references
* Updated doc comments
* Detailed how to override ZSH options set by the quickstart
* Sorted list of included plugins
* Updated TOC in Readme.md