### PR TITLE
Fix conflicting error message ".zsh_functions:161: defining function based on alias `chgext'"

### DIFF
--- a/zsh/.zsh_functions
+++ b/zsh/.zsh_functions
@@ -157,14 +157,6 @@ show_terminal_colors() {
   done
 }
 
-# Batch change extension from $1 to $2
-chgext() {
-  for file in *.$1
-  do
-    mv $file $(echo $file | sed "s/\(.*\.\)$1/\1$2/")
-  done
-}
-
 # Probe a /24 for hosts
 scan24() {
   nmap -sP ${1}/24


### PR DESCRIPTION
See issue #53.

'chgext' function is defined in `zsh/.zsh_functions` which conflicts with the alias defined in default plugin `unixorn/jpb.zshplugin` causing an error for each new terminal:

```
Last login: Fri Jan 25 12:35:53 on ttys005
Identity added: /Users/jmcculloch/.ssh/id_rsa (...)
/Users/jmcculloch/.zsh_functions:161: defining function based on alias `chgext'
/Users/jmcculloch/.zsh_functions:161: parse error near `()'
```
