### PR TITLE
Hacktoberfest update to options and ssh key handling

### DIFF
--- a/zsh/.zsh_functions
+++ b/zsh/.zsh_functions
@@ -192,6 +192,7 @@ pjson() {
 zombie() {
   ps aux | awk '{if ($8=="Z") { print $2 }}'
 }
+alias zombies=zombie
 
 # get the content type of an http resource
 # from https://github.com/jleclanche/dotfiles/blob/master/.zshrc

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -89,14 +89,12 @@ setopt hist_ignore_space
 setopt hist_reduce_blanks
 setopt hist_save_no_dups
 setopt hist_verify
+setopt INC_APPEND_HISTORY
+unsetopt HIST_BEEP
 
 # Share your history across all your terminal windows
 setopt share_history
 #setopt noclobber
-
-# set some more options
-setopt pushd_ignore_dups
-#setopt pushd_silent
 
 # Keep a ton of history. You can reset these without editing .zshrc by
 # adding a file to ~/.zshrc.d.
@@ -104,6 +102,24 @@ HISTSIZE=100000
 SAVEHIST=100000
 HISTFILE=~/.zsh_history
 export HISTIGNORE="ls:cd:cd -:pwd:exit:date:* --help"
+
+# set some options about directories
+setopt pushd_ignore_dups
+#setopt pushd_silent
+setopt AUTO_CD  # If a command is issued that can’t be executed as a normal command,
+                # and the command is the name of a directory, perform the cd command
+                # to that directory.
+
+# Add some completions settings
+setopt ALWAYS_TO_END     # Move cursor to the end of a completed word.
+setopt AUTO_LIST         # Automatically list choices on ambiguous completion.
+setopt AUTO_MENU         # Show completion menu on a successive tab press.
+setopt AUTO_PARAM_SLASH  # If completed parameter is a directory, add a trailing slash.
+setopt COMPLETE_IN_WORD  # Complete from both ends of a word.
+unsetopt MENU_COMPLETE   # Do not autoselect the first completion entry.
+
+# Miscellaneous settings
+setopt INTERACTIVE_COMMENTS  # Enable comments in interactive shell.
 
 # Long running processes should return time after they complete. Specified
 # in seconds.

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -52,24 +52,28 @@ done
 export LSCOLORS='Exfxcxdxbxegedabagacad'
 export LS_COLORS='di=1;34;40:ln=35;40:so=32;40:pi=33;40:ex=31;40:bd=34;46:cd=34;43:su=0;41:sg=0;46:tw=0;42:ow=0;43:'
 
-# Fun with SSH
-if [ $(ssh-add -l | grep -c "The agent has no identities." ) -eq 1 ]; then
-  if [[ "$(uname -s)" == "Darwin" ]]; then
-    # macOS allows us to store ssh key pass phrases in the keychain, so try
-    # to load ssh keys using pass phrases stored in the macOS keychain.
-    #
-    # You can use ssh-add -K /path/to/key to store pass phrases into
-    # the macOS keychain
-    ssh-add -k
-  fi
-fi
+load-our-ssh-keys() {
+  # Fun with SSH
+  if [ $(ssh-add -l | grep -c "The agent has no identities." ) -eq 1 ]; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+      # macOS allows us to store ssh key pass phrases in the keychain, so try
+      # to load ssh keys using pass phrases stored in the macOS keychain.
+      #
+      # You can use ssh-add -K /path/to/key to store pass phrases into
+      # the macOS keychain
+      ssh-add -k
+    fi
 
-for key in $(find ~/.ssh -type f -a \( -name id_rsa -o -name id_dsa -name id_ecdsa \))
-do
-  if [ -f ${key} -a $(ssh-add -l | grep -c "${key//$HOME\//}" ) -eq 0 ]; then
-    # ssh-add ${key}
+    for key in $(find ~/.ssh -type f -a \( -name '*id_rsa' -o -name '*id_dsa' -name '*id_ecdsa' \))
+    do
+      if [ -f ${key} -a $(ssh-add -l | grep -c "${key//$HOME\//}" ) -eq 0 ]; then
+        # ssh-add ${key}
+      fi
+    done
   fi
-done
+}
+
+load-our-ssh-keys
 
 # Now that we have $PATH set up and ssh keys loaded, configure zgen.
 


### PR DESCRIPTION
# option settings updates

* Update history handling options
* Add completions options
* Explicitly enable INTERACTIVE_COMMENTS

# SSH handling

* Move ssh key handling into a `load-our-ssh-keys` function to make it possible to reload ssh keys in a running session conveniently.
* Fix bug where we were trying to load all our ssh private keys every new shell session instead of only when no keys are present in our `ssh-agent` process
* Try to automatically load files suffixed `id_rsa`, `id_dsa` and `id_ecdsa` instead of only the default key names