### PR TITLE
Enable zmv, allow disabling oh-my-zsh

### DIFF
--- a/.zgen-local-plugins-example
+++ b/.zgen-local-plugins-example
@@ -16,7 +16,9 @@
 ZGEN_LOADED=()
 ZGEN_COMPLETIONS=()
 
-zgen oh-my-zsh
+if [[ ! -f ~/.zsh-quickstart-no-omz ]]; then
+  zgen oh-my-zsh
+fi
 
 # If you want to customize your plugin list, create a file named
 # .zgen-local-plugins in your home directory. That file will be sourced
@@ -70,18 +72,20 @@ zgen load peterhurford/git-it-on.zsh
 # in a repository securely by encrypting them with gnupg
 zgen load StackExchange/blackbox
 
-# Load some oh-my-zsh plugins
-zgen oh-my-zsh plugins/pip
-zgen oh-my-zsh plugins/sudo
-zgen oh-my-zsh plugins/aws
-zgen oh-my-zsh plugins/chruby
-zgen oh-my-zsh plugins/colored-man-pages
-zgen oh-my-zsh plugins/git
-zgen oh-my-zsh plugins/github
-zgen oh-my-zsh plugins/python
-zgen oh-my-zsh plugins/rsync
-zgen oh-my-zsh plugins/screen
-zgen oh-my-zsh plugins/vagrant
+if [[ ! -f ~/.zsh-quickstart-no-omz ]]; then
+  # Load some oh-my-zsh plugins
+  zgen oh-my-zsh plugins/pip
+  zgen oh-my-zsh plugins/sudo
+  zgen oh-my-zsh plugins/aws
+  zgen oh-my-zsh plugins/chruby
+  zgen oh-my-zsh plugins/colored-man-pages
+  zgen oh-my-zsh plugins/git
+  zgen oh-my-zsh plugins/github
+  zgen oh-my-zsh plugins/python
+  zgen oh-my-zsh plugins/rsync
+  zgen oh-my-zsh plugins/screen
+  zgen oh-my-zsh plugins/vagrant
+fi
 
 if [ $(uname -a | grep -ci Darwin) = 1 ]; then
   # Load OSX-specific plugins

--- a/Changes.md
+++ b/Changes.md
@@ -5,14 +5,15 @@
 * Stop stepping on OS-provided `$PATH`.
 
 ## 0.5.2
+
 * Added zsh-autosuggestions plugin
 
 ## 0.5
 
 * Added Changes file
 * Switched to using `~/.zshrc.d` files instead of a single `.zshrc.local` file
-* Stopped trying to be so clever about modification times so newbs could understand how it was working
-* Made it easier for users to customize, we now allow them to use their own plugin list if they create `.zgen-local-plugins`
+* Stopped trying to be so clever about modification times so new users could understand how it was working
+* Made it easier for users to customize without having to maintain a fork, we now allow them to use their own plugin list if they create `.zgen-local-plugins`
 * Broke out a lot of the OS X specific functions and aliases into a separate plugin, [tumult.plugin.zsh](https://github.com/unixorn/tumult.plugin.zsh) that only loads itself when it detects it is being run on an OS X system.
 * Added font installation instructions for Linux
 * We now de-duplicate your $PATH after loading everything

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7
+
+* autoload zmv by default
+* Allow disabling oh-my-zsh inclusion by creating `~/.zsh-quickstart-no-omz`
+
 ## 0.6
 
 * Stop stepping on OS-provided `$PATH`.

--- a/Readme.md
+++ b/Readme.md
@@ -169,11 +169,11 @@ Make a file in `~/.zshrc.d` named something like `999-reset-aliases`. Since thos
 
 ## ZSH options.
 
-The quickstart kit does an opinionated (i.e. my way) setup of ZSH options and adds some functions and aliases I like on my systems. However, `~/.zshrc.d` is processed after the quickstart sets its aliases, functions and ZSH options, so if you don't care for something as set up in the quickstart, you can override the offending item in a shell fragment file there.
+The quickstart kit does an opinionated (i.e. my way) setup of ZSH options and adds some functions and aliases I like on my systems. However, `~/.zshrc.d` is processed _after_ the quickstart sets its aliases, functions and ZSH options, so if you don't care for something as set up in the quickstart, you can override the offending item in a shell fragment file there.
 
 ## Self-update Settings
 
-The quickstart kit will check for updates every seven days. If you want to change the interval, set `QUICKSTART_KIT_REFRESH_IN_DAYS` in a file in `~/.zshrc.d`. If you want to disable self updating entirely, add `unset QUICKSTART_KIT_REFRESH_IN_DAYS` in a file in `~/.zshrc.d`.
+The quickstart kit will automatically check for updates every seven days. If you want to change the interval, set `QUICKSTART_KIT_REFRESH_IN_DAYS` in a file in `~/.zshrc.d`. If you want to disable self updating entirely, add `unset QUICKSTART_KIT_REFRESH_IN_DAYS` in a file in `~/.zshrc.d`.
 
 ## Changing the zgen plugin list
 
@@ -185,9 +185,17 @@ I know that it's a pain to create `.zgen-local-plugins` from scratch, so to make
 
 Copy that to your `$HOME/.zgen-local-plugins`, change the list and the next time you start a terminal session you'll get your list instead of mine.
 
+## Disabling zmv
+
+The quickstart automatically autoloads zmv. If you want to disable that, create a file named `.zsh-quickstart-no-zmv` in your home directory.
+
+## Disabling oh-my-zsh
+
+If you don't want zgen to load the oh-my-zsh defaults, create `.zsh-quickstart-no-omz` in your home directory.
+
 # FAQ
 
-## Stow complains with a Warning! that stowing zsh would cause conflicts
+## Stow complains with a warning that stowing zsh would cause conflicts
 
 You ran `stow --target=/Users/YourUsername zsh` in the top level of the repo, and stow printed the following error:
 

--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -27,7 +27,9 @@ load-starter-plugin-list() {
   ZGEN_LOADED=()
   ZGEN_COMPLETIONS=()
 
-  zgen oh-my-zsh
+  if [[ ! -f ~/.zsh-quickstart-no-omz ]]; then
+    zgen oh-my-zsh
+  fi
 
   # If you want to customize your plugin list, create a file named
   # .zgen-local-plugins in your home directory. That file will be sourced
@@ -82,18 +84,20 @@ load-starter-plugin-list() {
   # in a repository securely by encrypting them with gnupg.
   zgen load StackExchange/blackbox
 
-  # Load some oh-my-zsh plugins
-  zgen oh-my-zsh plugins/pip
-  zgen oh-my-zsh plugins/sudo
-  zgen oh-my-zsh plugins/aws
-  zgen oh-my-zsh plugins/chruby
-  zgen oh-my-zsh plugins/colored-man-pages
-  zgen oh-my-zsh plugins/git
-  zgen oh-my-zsh plugins/github
-  zgen oh-my-zsh plugins/python
-  zgen oh-my-zsh plugins/rsync
-  zgen oh-my-zsh plugins/screen
-  zgen oh-my-zsh plugins/vagrant
+  if [[ ! -f ~/.zsh-quickstart-no-omz ]]; then
+    # Load some oh-my-zsh plugins
+    zgen oh-my-zsh plugins/pip
+    zgen oh-my-zsh plugins/sudo
+    zgen oh-my-zsh plugins/aws
+    zgen oh-my-zsh plugins/chruby
+    zgen oh-my-zsh plugins/colored-man-pages
+    zgen oh-my-zsh plugins/git
+    zgen oh-my-zsh plugins/github
+    zgen oh-my-zsh plugins/python
+    zgen oh-my-zsh plugins/rsync
+    zgen oh-my-zsh plugins/screen
+    zgen oh-my-zsh plugins/vagrant
+  fi
 
   if [ $(uname -a | grep -ci Darwin) = 1 ]; then
     # Load macOS-specific plugins

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -245,6 +245,11 @@ if [ -f ~/.zshrc.local ]; then
   echo 'Future versions of zsh-quickstart-kits will no longer load ~/.zshrc.local'
 fi
 
+# Load zmv
+if [[ ! -f ~/.zsh-quickstart-no-zmv ]]; then
+  autoload -U zmv
+fi
+
 # Make it easy to append your own customizations that override the above by
 # loading all files from the ~/.zshrc.d directory
 mkdir -p ~/.zshrc.d

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,15 +1,17 @@
 # Copyright 2006-2019 Joseph Block <jpb@apesseekingknowledge.net>
 #
 # BSD licensed, see LICENSE.txt
-
+#
 # Set this to use case-sensitive completion
 # CASE_SENSITIVE="true"
-
+#
 # Uncomment following line if you want to disable colors in ls
 # DISABLE_LS_COLORS="true"
-
+#
 # Uncomment following line if you want to disable autosetting terminal title.
 # DISABLE_AUTO_TITLE="true"
+#
+# Version 0.7
 
 # Valid font modes:
 # flat, awesome-patched, awesome-fontconfig, nerdfont-complete, nerdfont-fontconfig


### PR DESCRIPTION
* Enable zmv by default
* Add option to disable loading oh-my-zsh-defaults by creating `~/.zsh-quickstart-no-omz`
