### PR TITLE
Make powerlevel10k the default prompt

### DIFF
--- a/.zgen-local-plugins-example
+++ b/.zgen-local-plugins-example
@@ -30,7 +30,7 @@ warn-about-prompt-change() {
     echo
     echo "Run zsh-quickstart-select-powerlevel10k to switch to the new prompt"
     echo
-    echo "Sorry for any inconvenience."
+    echo "If you do nothing, you will be switched to powerlevel10k"
     echo
     touch ~/.zsh-quickstart-kit-prompt-switch-warning
   fi

--- a/.zgen-local-plugins-example
+++ b/.zgen-local-plugins-example
@@ -146,7 +146,7 @@ zgen load supercrabtree/k
 
 if [[ -f ~/.zsh-quickstart-use-bullet-train ]]; then
   # Bullet train prompt setup.
-  zgen load caiogondim/bullet-train-oh-my-zsh-theme bullet-train
+  zgen load https://github.com/caiogondim/bullet-train.zsh
 else
   # p10k is faster and what I'm using now, so it is the new default
   zgen load romkatv/powerlevel10k powerlevel10k

--- a/.zgen-local-plugins-example
+++ b/.zgen-local-plugins-example
@@ -2,7 +2,7 @@
 #
 # Only including a shebang to trigger Sublime Text to use shell syntax highlighting
 #
-# Copyright 2006-2017 Joseph Block <jpb@unixorn.net>
+# Copyright 2006-2020 Joseph Block <jpb@unixorn.net>
 #
 # The Zsh Starter Kit allows you to replace the curated plugins list it
 # ships with with a custom one by creating a file named .zgen-local-plugins.
@@ -11,7 +11,7 @@
 # fork of the starter kit.
 #
 # This example file duplicates the list of plugins that shipped with the
-# kit as of 2017-05-07.
+# kit as of 2020-01-01.
 
 ZGEN_LOADED=()
 ZGEN_COMPLETIONS=()
@@ -20,10 +20,32 @@ if [[ ! -f ~/.zsh-quickstart-no-omz ]]; then
   zgen oh-my-zsh
 fi
 
+warn-about-prompt-change() {
+  if [[ ! -f ~/.zsh-quickstart-kit-prompt-switch-warning ]]; then
+    echo
+    echo "The default ZSH prompt in the quickstart kit has changed from"
+    echo "bullet-train to powerlevel10k."
+    echo
+    echo "If you want to use the old prompt, run zsh-quickstart-select-bullet-train"
+    echo
+    echo "Run zsh-quickstart-select-powerlevel10k to switch to the new prompt"
+    echo
+    echo "Sorry for any inconvenience."
+    echo
+    touch ~/.zsh-quickstart-kit-prompt-switch-warning
+  fi
+}
+
 # If you want to customize your plugin list, create a file named
 # .zgen-local-plugins in your home directory. That file will be sourced
 # during startup *instead* of running this load-starter-plugin-list function,
-# so make sure to include everything from this function that you want to keep.
+# so make sure to include everything from this function that you want to
+# keep.
+#
+# To make customizing easier, there's a .zgen-local-plugins-example file
+# at the top level of the zsh-quickstart-kit repository that you can copy
+# as a starting point. This keeps you from having to maintain a fork of
+# the quickstart kit.
 
 # If zsh-syntax-highlighting is bundled after zsh-history-substring-search,
 # they break, so get the order right.
@@ -35,41 +57,42 @@ zmodload zsh/terminfo
 bindkey "$terminfo[kcuu1]" history-substring-search-up
 bindkey "$terminfo[kcud1]" history-substring-search-down
 
-# Tab complete rakefile targets
+# Tab complete rakefile targets.
 zgen load unixorn/rake-completion.zshplugin
 
-# Automatically run zgen update and zgen selfupdate every 7 days
+# Automatically run zgen update and zgen selfupdate every 7 days.
 zgen load unixorn/autoupdate-zgen
 
-# Add my random utility functions
+# Add my collection of miscellaneous utility functions.
 zgen load unixorn/jpb.zshplugin
 
 # Colorize the things if you have grc installed. Well, some of the
 # things, anyway.
 zgen load unixorn/warhol.plugin.zsh
 
-# OS X helpers. This plugin is smart enough to detect when it isn't running
-# on OS X and not load itself, so you can safely share the same plugin list
-# across OS X and Linux/BSD
+# macOS helpers. This plugin is smart enough to detect when it isn't running
+# on macOS and not load itself, so you can safely share the same plugin list
+# across macOS and Linux/BSD.
 zgen load unixorn/tumult.plugin.zsh
 
-# Warn you when you run a command that you've set an alias for
+# Warn you when you run a command that you've set an alias for without
+# using the alias.
 zgen load djui/alias-tips
 
-# Add my collection of git helper scripts
+# Add my collection of git helper scripts.
 zgen load unixorn/git-extra-commands
 
-# Add my bitbucket git helpers plugin
+# Add my bitbucket git helpers plugin.
 zgen load unixorn/bitbucket-git-helpers.plugin.zsh
 
-# A collection of scripts that might be useful to sysadmins
+# A collection of scripts that might be useful to sysadmins.
 zgen load skx/sysadmin-util
 
 # Adds aliases to open your current repo & branch on github.
 zgen load peterhurford/git-it-on.zsh
 
 # Tom Limoncelli's tooling for storing private information (keys, etc)
-# in a repository securely by encrypting them with gnupg
+# in a repository securely by encrypting them with gnupg.
 zgen load StackExchange/blackbox
 
 if [[ ! -f ~/.zsh-quickstart-no-omz ]]; then
@@ -88,7 +111,7 @@ if [[ ! -f ~/.zsh-quickstart-no-omz ]]; then
 fi
 
 if [ $(uname -a | grep -ci Darwin) = 1 ]; then
-  # Load OSX-specific plugins
+  # Load macOS-specific plugins
   zgen oh-my-zsh plugins/brew
   zgen oh-my-zsh plugins/osx
 fi
@@ -99,7 +122,7 @@ zgen load sharat87/pip-app
 
 zgen load chrissicool/zsh-256color
 
-# Load more completion files for zsh from the zsh-lovers github repo
+# Load more completion files for zsh from the zsh-lovers github repo.
 zgen load zsh-users/zsh-completions src
 
 # Docker completion
@@ -113,15 +136,22 @@ GENCOMPL_FPATH=$HOME/.zsh/complete
 # you'll have to explicitly generate a completion, but it's still quite cool.
 zgen load RobSis/zsh-completion-generator
 
-# Add Fish-like autosuggestions to your ZSH
+# Add Fish-like autosuggestions to your ZSH.
 zgen load zsh-users/zsh-autosuggestions
 
 # k is a zsh script / plugin to make directory listings more readable,
-# adding a bit of color and some git status information on files and directories
+# adding a bit of color and some git status information on files and
+# directories.
 zgen load supercrabtree/k
 
-# Bullet train prompt setup
-zgen load caiogondim/bullet-train-oh-my-zsh-theme bullet-train
+if [[ -f ~/.zsh-quickstart-use-bullet-train ]]; then
+  # Bullet train prompt setup.
+  zgen load caiogondim/bullet-train-oh-my-zsh-theme bullet-train
+else
+  # p10k is faster and what I'm using now, so it is the new default
+  zgen load romkatv/powerlevel10k powerlevel10k
+  warn-about-prompt-change
+fi
 
 # Save it all to init script
 zgen save

--- a/Changes.md
+++ b/Changes.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 1.0.0
+
+* It's been four years, this is 1.0
+* Switch to powerlevel10k prompt instead of bullettrain. If you want to keep bullettrain, run `zsh-quickstart-select-bullettrain`, and you can switch to p10k with `zsh-quickstart-select-powerlevel10k`
+
 ## 0.7
 
-* autoload zmv by default
+* autoload `zmv` by default
 * Allow disabling oh-my-zsh inclusion by creating `~/.zsh-quickstart-no-omz`
 
 ## 0.6
@@ -21,5 +26,5 @@
 * Made it easier for users to customize without having to maintain a fork, we now allow them to use their own plugin list if they create `.zgen-local-plugins`
 * Broke out a lot of the OS X specific functions and aliases into a separate plugin, [tumult.plugin.zsh](https://github.com/unixorn/tumult.plugin.zsh) that only loads itself when it detects it is being run on an OS X system.
 * Added font installation instructions for Linux
-* We now de-duplicate your $PATH after loading everything
+* We now de-duplicate your `$PATH` after loading everything
 * Added self-update capability

--- a/Readme.md
+++ b/Readme.md
@@ -164,6 +164,14 @@ The quickstart kit also uses `zgen` to load oh-my-zsh and these plugins:
 
 # Customizing the kit
 
+## Behavior toggles
+
+Running the following commands will toggle behavior the next time you start a shell session:
+
+* `zsh-quickstart-disable-omz-plugins` - Makes the stock quickstart not load any of the oh-my-zsh plugins it would normally use. You can re-enable them with `zsh-quickstart-enable-omz-plugins`.
+* `zsh-quickstart-select-powerlevel10k` - I've switched to using the [powerlevel10k](https://github.com/romkatv/powerlevel10k) prompt since I first wrote this quickstart. I feel like I shouldn't change the prompt out from under people without a way for them to get the old behavior, so I'm providing toggle commands to switch between it and the [bullet-train](https://github.com/caiogondim/bullet-train.zsh) prompt I originally used in the kit.
+* `zsh-quickstart-select-bullettrain` - Switch back to the old bullet-train prompt.
+
 ## Functions and Aliases
 
 The `.zshrc` included in this kit will automatically source any files it finds in `~/.zshrc.d`. This makes it easy for you to add extra functions and aliases without having to maintain a separate fork of this repository. The files will be sourced in alphanumeric order after loading all the plugins and I suggest you use a naming scheme of `001-onething`, `002-something-else` etc to ensure they're loaded in the order you expect.
@@ -182,7 +190,9 @@ The quickstart kit will automatically check for updates every seven days. If you
 
 ## Changing the zgen plugin list
 
-I've included what I think is a good starter set of zsh plugins in this repository. However, everyone has their own preferences for their environment. To make the list easier to customize without having to maintain a separate fork of this kit, if you create a file named `~/.zgen-local-plugins`, the `.zshrc` from this starter kit will source that **instead** of running the `load-starter-plugin-list` function defined in `~/.zgen-setup`.
+I've included what I think is a good starter set of zsh plugins in this repository. However, everyone has their own preferences for their environment.
+
+To make the list easier to customize without having to maintain a separate fork of this kit, if you create a file named `~/.zgen-local-plugins`, the `.zshrc` from this starter kit will source that **instead** of running the `load-starter-plugin-list` function defined in `~/.zgen-setup`.
 
 **Using `~/.zgen-local-plugins` is not additive, it will _completely replace_ the kit-provided list of plugins.**
 
@@ -225,7 +235,7 @@ compinit
 
 ## ZSH
 
-* For a list of other ZSH plugins, completions and themes you might like to use, check out my [awesome-zsh-plugins](https://github.com/unixorn/awesome-zsh-plugins) list. It also contains a list of [ZSH tutorials](https://github.com/unixorn/awesome-zsh-plugins#generic-zsh).
+* For a list of other ZSH plugins, completions and themes you might like to use, check out my [awesome-zsh-plugins](https://github.com/unixorn/awesome-zsh-plugins) list. It also contains a list of other ZSH [tutorials and starter kits](https://github.com/unixorn/awesome-zsh-plugins#generic-zsh).
 * Justin Garrison has a good repo that details [Mastering ZSH](https://github.com/rothgar/mastering-zsh).
 
 ## Dotfiles in general

--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -157,7 +157,7 @@ load-starter-plugin-list() {
 
   if [[ -f ~/.zsh-quickstart-use-bullet-train ]]; then
     # Bullet train prompt setup.
-    zgen load caiogondim/bullet-train-oh-my-zsh-theme bullet-train
+    zgen load https://github.com/caiogondim/bullet-train.zsh
   else
     # p10k is faster and what I'm using now, so it is the new default
     zgen load romkatv/powerlevel10k powerlevel10k

--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -22,6 +22,22 @@ fi
 source $ZGEN_PARENT_DIR/zgen/zgen.zsh
 unset ZGEN_PARENT_DIR
 
+warn-about-prompt-change() {
+  if [[ ! -f ~/.zsh-quickstart-kit-prompt-switch-warning ]]; then
+    echo
+    echo "The default ZSH prompt in the quickstart kit has changed from"
+    echo "bullet-train to powerlevel10k."
+    echo
+    echo "If you want to use the old prompt, run zsh-quickstart-select-bullet-train"
+    echo
+    echo "Run zsh-quickstart-select-powerlevel10k to switch to the new prompt"
+    echo
+    echo "If you do nothing, you will be switched to powerlevel10k"
+    echo
+    touch ~/.zsh-quickstart-kit-prompt-switch-warning
+  fi
+}
+
 load-starter-plugin-list() {
   echo "Creating a zgen save"
   ZGEN_LOADED=()
@@ -34,7 +50,13 @@ load-starter-plugin-list() {
   # If you want to customize your plugin list, create a file named
   # .zgen-local-plugins in your home directory. That file will be sourced
   # during startup *instead* of running this load-starter-plugin-list function,
-  # so make sure to include everything from this function that you want to keep.
+  # so make sure to include everything from this function that you want to
+  # keep.
+  #
+  # To make customizing easier, there's a .zgen-local-plugins-example file
+  # at the top level of the zsh-quickstart-kit repository that you can copy
+  # as a starting point. This keeps you from having to maintain a fork of
+  # the quickstart kit.
 
   # If zsh-syntax-highlighting is bundled after zsh-history-substring-search,
   # they break, so get the order right.
@@ -133,8 +155,14 @@ load-starter-plugin-list() {
   # directories.
   zgen load supercrabtree/k
 
-  # Bullet train prompt setup.
-  zgen load caiogondim/bullet-train-oh-my-zsh-theme bullet-train
+  if [[ -f ~/.zsh-quickstart-use-bullet-train ]]; then
+    # Bullet train prompt setup.
+    zgen load caiogondim/bullet-train-oh-my-zsh-theme bullet-train
+  else
+    # p10k is faster and what I'm using now, so it is the new default
+    zgen load romkatv/powerlevel10k powerlevel10k
+    warn-about-prompt-change
+  fi
 
   # Save it all to init script.
   zgen save

--- a/zsh/.zsh_aliases
+++ b/zsh/.zsh_aliases
@@ -136,10 +136,6 @@ if [ -x /sw/bin/ldapsearch ];then
   alias ldapsearch=/usr/bin/ldapsearch
 fi
 
-if [ -x /usr/bin/vagrant ]; then
-  alias vagrant="/usr/bin/vagrant"
-fi
-
 # Use brew versions if present
 if [ -x /usr/local/bin/mysql/bin/mysql ]; then
   alias mysql="/usr/local/mysql/bin/mysql"

--- a/zsh/.zsh_functions
+++ b/zsh/.zsh_functions
@@ -2,9 +2,34 @@
 #
 # Only including a shebang to trigger Sublime Text to use shell syntax highlighting
 #
-# Copyright 2006-2019 Joseph Block <jpb@unixorn.net>
+# Copyright 2006-2020 Joseph Block <jpb@unixorn.net>
 #
 # BSD licensed, see LICENSE.txt
+#
+# If you want to customize these, the best thing to do is override them
+# with a shell fragment in ~/.zshrc.d, then you don't have to maintain
+# your own fork of the quickstart kit
+
+# Add some quickstart toggle functions
+zsh-quickstart-select-bullet-train() {
+  touch ~/.zsh-quickstart-use-bullet-train
+  rm -f ~/.zgen/init.zsh
+}
+
+zsh-quickstart-select-powerlevel10k() {
+  rm -f ~/.zsh-quickstart-use-bullet-train
+  rm -f ~/.zgen/init.zsh
+}
+
+zsh-quickstart-disable-omz-plugins() {
+  touch ~/.zsh-quickstart-no-omz
+  rm -f ~/.zgen/init.zsh
+}
+
+zsh-quickstart-enable-omz-plugins() {
+  rm -f ~/.zsh-quickstart-no-omz
+  rm -f ~/.zgen/init.zsh
+}
 
 exists() {
   if (( $+commands[$1] )); then return 0; else return 1; fi
@@ -26,6 +51,11 @@ hgrep() {
 
 hgrep_full() {
   history | egrep --color -i "$@"
+}
+
+# easier to type, leaving hgrep_full for backwards compatibility
+hgrep-full() {
+  hgrep_full "$@"
 }
 
 envgrep() {


### PR DESCRIPTION
Switch default prompt to p10k

* Switch the default prompt to p10k
* Print instructions for how to revert to bullet-train the first time a new session uses p10k
* Add helper functions to make toggling the prompt and whether we load OMZ easier
* Add a few more aliases to baked in functions to make typing them easier
* Update url for bullet-train since the repo path has been changed upstream
* Update the example `.zgen-local-plugins` file