### PR TITLE
Make it possible to disable printing the ssh key list during login

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -171,6 +171,7 @@ Running the following commands will toggle behavior the next time you start a sh
 * `zsh-quickstart-disable-omz-plugins` - Makes the stock quickstart not load any of the oh-my-zsh plugins it would normally use. You can re-enable them with `zsh-quickstart-enable-omz-plugins`.
 * `zsh-quickstart-select-powerlevel10k` - I've switched to using the [powerlevel10k](https://github.com/romkatv/powerlevel10k) prompt since I first wrote this quickstart. I feel like I shouldn't change the prompt out from under people without a way for them to get the old behavior, so I'm providing toggle commands to switch between it and the [bullet-train](https://github.com/caiogondim/bullet-train.zsh) prompt I originally used in the kit.
 * `zsh-quickstart-select-bullet-train` - Switch back to the old bullet-train prompt.
+* You can disable printing the list of `ssh` keys by setting `DONT_PRINT_SSH_KEY_LIST` in a file in `~/.zshrc.d`.
 
 ## Functions and Aliases
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -242,11 +242,6 @@ if [ -d ~/.zsh-completions ]; then
   done
 fi
 
-echo
-echo "Current SSH Keys:"
-ssh-add -l
-echo
-
 # Honor old .zshrc.local customizations, but print deprecation warning.
 if [ -f ~/.zshrc.local ]; then
   source ~/.zshrc.local
@@ -350,4 +345,11 @@ if [[ ! -f ~/.p10k.zsh ]]; then
   echo "Run p10k configure or edit ~/.p10k.zsh to configure your prompt"
 else
   source ~/.p10k.zsh
+fi
+
+if [[ -z "$DONT_PRINT_SSH_KEY_LIST" ]]; then
+  echo
+  echo "Current SSH Keys:"
+  ssh-add -l
+  echo
 fi


### PR DESCRIPTION
Users can now disable printing the list of keys by setting `DONT_PRINT_SSH_KEY_LIST` in a file in `~/.zshrc.d`.

I wanted to add the ability to disable without changing the behavior for existing users.

Closes #75.