### PR TITLE
Improve usage of grc

### DIFF
--- a/zsh/.zsh_aliases
+++ b/zsh/.zsh_aliases
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env zsh
 #
-# Only including a shebang to trigger Sublime Text to use shell syntax highlighting
+# Only including a shebang to trigger editors to use shell syntax highlighting
 #
 # Copyright 2006-2021 Joseph Block <jpb@unixorn.net>
 #
@@ -17,14 +17,13 @@ fi
 
 # Yes, these tests are ugly. They do however, work.
 if [[ "$(uname -s)" == "Darwin" ]]; then
-  # do OS X specific things
-
+  # do macOS specific things
   alias top="TERM=vt100 top"
 else
   alias cputop="top -o cpu"
   alias l-d="ls -lad"
-  alias l="ls -la"
-  alias ll="ls -la | less"
+  alias l="ls -lah"
+  alias ll="ls -lah | less"
 fi
 
 if [[ "$(uname -s)" == "Linux" ]]; then
@@ -32,6 +31,15 @@ if [[ "$(uname -s)" == "Linux" ]]; then
   alias l-d="ls -lFad"
   alias l="ls -laF"
   alias ll="ls -lFa | TERM=vt100 less"
+fi
+
+# Set up colorized ls when grc is present
+# shellcheck disable=SC2154
+if (( $+commands[grc] )); then
+  alias ls="gls -F --color"
+  alias l="gls -lAh --color"
+  alias ll="gls -l --color"
+  alias la='gls -A --color'
 fi
 
 export CVS_RSH=ssh

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -105,6 +105,9 @@ if [ -f ~/.zgen-setup ]; then
 fi
 
 # Set some history options
+#
+# You can customize these by putting a file in ~/.zshrc.d with
+# different settings.
 setopt append_history
 setopt extended_history
 setopt hist_expire_dups_first
@@ -121,7 +124,7 @@ unsetopt HIST_BEEP
 setopt share_history
 #setopt noclobber
 
-# Keep a ton of history. You can reset these without editing .zshrc by
+# Keep a ton of history. You can override these without editing .zshrc by
 # adding a file to ~/.zshrc.d that changes these variables.
 HISTSIZE=100000
 SAVEHIST=100000
@@ -240,9 +243,22 @@ fi
 
 # grc colorizes the output of a lot of commands. If the user installed it,
 # use it.
-if [ -f /usr/local/etc/grc.bashrc ]; then
-  source "$(brew --prefix)/etc/grc.bashrc"
 
+# Try and find the grc setup file
+if (( $+commands[grc] )); then
+  GRC_SETUP='/usr/local/etc/grc.bashrc'
+fi
+if (( $+commands[grc] )) && (( $+commands[brew] ))
+then
+  GRC_SETUP="$(brew --prefix)/etc/grc.bashrc"
+fi
+if [[ -r "$GRC_SETUP" ]]; then
+  source "$GRC_SETUP"
+fi
+unset GRC_SETUP
+
+if (( $+commands[grc] )) 
+then
   function ping5(){
     grc --color=auto ping -c 5 "$@"
   }


### PR DESCRIPTION
- Check for brew-install path to `grc.bashrc` if brew is installed instead of assuming `/usr/local/etc/grc.bashrc`
- Update `.zshrc` to tell user where to override the `setopt` settings provided by the quickstart.