### PR TITLE
Update stale reference to ~/.zgen/init.zsh

### DIFF
--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -252,7 +252,7 @@ fi
 # echo "REAL_ZGEN_ZETUP: $REAL_ZGEN_SETUP"
 
 # If .zgen-setup is newer than init.zsh, regenerate init.zsh
-if [ $(get_file_modification_time ${REAL_ZGEN_SETUP}) -gt $(get_file_modification_time ~/.zgen/init.zsh) ]; then
+if [ $(get_file_modification_time ${REAL_ZGEN_SETUP}) -gt $(get_file_modification_time ~/.zgenom/init.zsh) ]; then
   echo "$(basename ${REAL_ZGEN_SETUP}) updated; creating a new init.zsh from plugin list in ${REAL_ZGEN_SETUP}"
   setup-zgen-repos
 fi


### PR DESCRIPTION
This commit updates a stale reference to `~/.zgen/init.zsh` in `zsh/.zgen-setup`, to `~/.zgenom/init.zsh`.
Fixes #106