### PR TITLE
Trap sigint and print a ^C

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -184,6 +184,7 @@ Running the following commands will toggle behavior the next time you start a sh
   * `zsh-quickstart-select-powerlevel10k` -  Switch to the [powerlevel10k](https://github.com/romkatv/powerlevel10k) prompt now used as the kit's default.
   * `zsh-quickstart-select-bullet-train` - Switch back to the [bullet-train](https://github.com/caiogondim/bullet-train.zsh) prompt originally used in the kit.
 * You can disable printing the list of `ssh` keys by setting `DONT_PRINT_SSH_KEY_LIST` in a file in `~/.zshrc.d`.
+* `bash` prints `^C` when you're typing a command and control-c to cancel, so it is easy to see it wasn't executed. By default, ZSH doesn't print the `^C`. I like seeing the `^C`, so by default the quickstart traps `SIGINT` and prints the `^C`. You can disable this by exporting `ZSH_QUICKSTART_SKIP_TRAPINT='false'` in one of the files in `~/.zshrc.d`.
 
 ### Functions and Aliases
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -432,3 +432,14 @@ if [[ -z "$DONT_PRINT_SSH_KEY_LIST" ]]; then
   ssh-add -l
   echo
 fi
+
+if [[ -z "ZSH_QUICKSTART_SKIP_TRAPINT" ]]; then
+  # Original source: https://vinipsmaker.wordpress.com/2014/02/23/my-zsh-config/
+  # bash prints ^C when you're typing a command and control-c to cancel, so it
+  # is easy to see it wasn't executed. By default, ZSH doesn't print the ^C.
+  # We trap SIGINT to make it print the ^C.
+  TRAPINT() {
+    print -n -u2 '^C'
+    return $((128+$1))
+  }
+fi


### PR DESCRIPTION
bash prints `^C` when you're typing a command and control-c to cancel, so it is easy to see it wasn't executed. By default, ZSH doesn't print the `^C`. I like seeing the `^C`, so by default the quickstart now traps `SIGINT` and prints the `^C`.