### PR TITLE
Don't use framework-specific name for plugin override file

### DIFF
--- a/.zsh-quickstart-local-plugins-example
+++ b/.zsh-quickstart-local-plugins-example
@@ -5,7 +5,7 @@
 # Copyright 2006-2021 Joseph Block <jpb@unixorn.net>
 #
 # The ZSH Starter Kit allows you to replace the curated plugins list it
-# ships with with a custom one by creating a file named .zgen-local-plugins.
+# ships with with a custom one by creating a file named .zsh-quickstart-local-plugins.
 #
 # This is to make it easier to customize without having to maintain a separate
 # fork of the starter kit.
@@ -37,13 +37,13 @@ warn-about-prompt-change() {
 }
 
 # If you want to customize your plugin list, create a file named
-# .zgen-local-plugins in your home directory. That file will be sourced
+# .zsh-quickstart-local-plugins in your home directory. That file will be sourced
 # during startup *instead* of running this load-starter-plugin-list function,
 # so make sure to include everything from this function that you want to
 # keep.
 #
-# To make customizing easier, there's a .zgen-local-plugins-example file
-# at the top level of the zsh-quickstart-kit repository that you can copy
+# To make customizing easier, there's a .zsh-quickstart-local-plugins-example
+# file at the top level of the zsh-quickstart-kit repository that you can copy
 # as a starting point. This keeps you from having to maintain a fork of
 # the quickstart kit.
 

--- a/Readme.md
+++ b/Readme.md
@@ -56,6 +56,7 @@ This quickstart includes the [powerlevel10k](https://github.com/romkatv/powerlev
 Here are a few good Powerline-compatible fonts:
 
 * [Awesome Terminal Fonts](https://github.com/gabrielelana/awesome-terminal-fonts) - A family of fonts that includes some nice monospaced Icons.
+* [Cascadia Code](https://github.com/microsoft/cascadia-code) - Microsoft's Cascadia Code
 * [Fantasque Awesome Font](https://github.com/ztomer/fantasque_awesome_powerline) - A nice monospaced font, patched with Font-Awesome, Octoicons and Powerline-Glyphs.
 * [Fira Mono](https://github.com/mozilla/Fira) - Mozilla's Fira type family.
 * [Hack](http://sourcefoundry.org/hack/) - Another Powerline-compatible font designed specifically for source code and terminal usage.

--- a/Readme.md
+++ b/Readme.md
@@ -216,13 +216,13 @@ The quickstart kit will automatically check for updates every seven days. If you
 
 I've included what I think is a good starter set of ZSH plugins in this repository. However, everyone has their own preferences for their own environment.
 
-To make the list easier to customize without having to maintain a separate fork of the quickstart kit, if you create a file named `~/.zgen-local-plugins`, the `.zshrc` from this starter kit will source that **instead** of running the `load-starter-plugin-list` function defined in `~/.zgen-setup`.
+To make the list easier to customize without having to maintain a separate fork of the quickstart kit, if you create a file named `~/.zsh-quickstart-local-plugins`, the `.zshrc` from this starter kit will source that **instead** of running the `load-starter-plugin-list` function defined in `~/.zgen-setup`.
 
-**Using `~/.zgen-local-plugins` is not additive, it will _completely replace_ the kit-provided list of plugins.**
+**Using `~/.zsh-quickstart-local-plugins` is not additive, it will _completely replace_ the kit-provided list of plugins.**
 
-I realize that it would be a pain to create `.zgen-local-plugins` from scratch, so to make customizing your plugins easier, I've included a `.zgen-local-plugins-example` file at the root of the repository that will install the same plugin list that the kit does by default that you can use as a starting point for your own customizations.
+I realize that it would be a pain to create `.zsh-quickstart-local-plugins` from scratch, so to make customizing your plugins easier, I've included a `.zsh-quickstart-local-plugins-example` file at the root of the repository that will install the same plugin list that the kit does by default that you can use as a starting point for your own customizations.
 
-Copy that to your `$HOME/.zgen-local-plugins`, change the list and the next time you start a terminal session you'll get your plugin list loaded instead of the kit's defaults.
+Copy that to your `$HOME/.zsh-quickstart-local-plugins`, change the list and the next time you start a terminal session you'll get your plugin list loaded instead of the kit's defaults.
 
 ### Disabling zmv
 

--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -61,14 +61,14 @@ load-starter-plugin-list() {
   fi
 
   # If you want to customize your plugin list, create a file named
-  # .zgen-local-plugins in your home directory. That file will be sourced
-  # during startup *instead* of running this load-starter-plugin-list function,
-  # so make sure to include everything from this function that you want to
-  # keep.
+  # .zsh-quickstart-local-plugins-example in your home directory. That 
+  # file will be sourced during startup *instead* of running this
+  # load-starter-plugin-list function, so make sure to include everything
+  # from this function that you want to keep.
   #
-  # To make customizing easier, there's a .zgen-local-plugins-example file
-  # at the top level of the zsh-quickstart-kit repository that you can copy
-  # as a starting point. This keeps you from having to maintain a fork of
+  # To make customizing easier, there's a .zsh-quickstart-local-plugins-example
+  # file at the top level of the zsh-quickstart-kit repository that you can
+  # copy as a starting point. This keeps you from having to maintain a fork of
   # the quickstart kit.
 
   # If zsh-syntax-highlighting is bundled after zsh-history-substring-search,
@@ -186,8 +186,20 @@ load-starter-plugin-list() {
 }
 
 setup-zgen-repos() {
-  if [[ -f ~/.zgen-local-plugins ]]; then
-    source ~/.zgen-local-plugins
+  ZQS_override_plugin_list=''
+  # Check the old name for backward compatibility
+  if [[ -r $HOME/.zgen-local-plugins ]]; then
+    ZQS_override_plugin_list="$HOME/.zgen-local-plugins"
+  fi
+  # If they have both, the new name takes precedence
+  if [[ -r $HOME/.zsh-quickstart-local-plugins ]]; then
+    ZQS_override_plugin_list="$HOME/.zsh-quickstart-local-plugins"
+  fi
+
+  if [[ -r "$ZQS_override_plugin_list" ]]; then
+    echo "Loading local plugin list from $ZQS_override_plugin_list"
+    source "$ZQS_override_plugin_list"
+    unset ZQS_override_plugin_list
   else
     load-starter-plugin-list
   fi
@@ -234,8 +246,8 @@ if [[ -L ~/.zgen-setup ]]; then
 fi
 
 # If you don't want my standard starter set of plugins, create a file named
-# .zgen-local-plugins and add your zgenom load commands there. Don't forget to
-# run `zgen save` at the end of your .zgen-local-plugins file.
+# .zsh-quickstart-local-plugins and add your zgenom load commands there. Don't forget to
+# run `zgen save` at the end of your .zsh-quickstart-local-plugins file.
 #
 # Warning: .zgen-local-plugins REPLACES the starter list setup, it doesn't
 # add to it.
@@ -247,6 +259,14 @@ if [[ -f ~/.zgen-local-plugins ]]; then
 fi
 if [[ -L ~/.zgen-local-plugins ]]; then
   REAL_ZGEN_SETUP="${HOME}/$(readlink ~/.zgen-local-plugins)"
+fi
+# Old file still works for backward compatibility, but we want the new file
+# to take precedence when both exist.
+if [[ -f ~/.zsh-quickstart-local-plugins ]]; then
+  REAL_ZGEN_SETUP=~/.zsh-quickstart-local-plugins
+fi
+if [[ -L ~/.zsh-quickstart-local-plugins ]]; then
+  REAL_ZGEN_SETUP="${HOME}/$(readlink ~/.zsh-quickstart-local-plugins)"
 fi
 
 # echo "REAL_ZGEN_ZETUP: $REAL_ZGEN_SETUP"

--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -273,7 +273,7 @@ fi
 
 # If .zgen-setup is newer than init.zsh, regenerate init.zsh
 if [ $(get_file_modification_time ${REAL_ZGEN_SETUP}) -gt $(get_file_modification_time ~/.zgenom/init.zsh) ]; then
-  echo "$(basename ${REAL_ZGEN_SETUP}) updated; creating a new init.zsh from plugin list in ${REAL_ZGEN_SETUP}"
+  echo "$(basename ${REAL_ZGEN_SETUP}) ($REAL_ZGEN_SETUP) updated; creating a new init.zsh from plugin list in ${REAL_ZGEN_SETUP}"
   setup-zgen-repos
 fi
 unset REAL_ZGEN_SETUP


### PR DESCRIPTION
Replace `.zgen-local-plugins` with `.zsh-quickstart-local-plugins`, and make `.zsh-quickstart-local-plugins` have precedence if both exist.