### PR TITLE
Delete unused `has` fn (was renamed -> `can_haz`)

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -21,10 +21,6 @@
 # quickstart kit.
 
 # Check if a command exists
-function has() {
-  which "$@" > /dev/null 2>&1
-}
-
 function can_haz() {
   which "$@" > /dev/null 2>&1
 }


### PR DESCRIPTION
In [a previous commit](https://github.com/unixorn/zsh-quickstart-kit/commit/3494ddcde5db247a9913a993616935c784002b1b), the `has` function in `.zshrc` was renamed to `can_haz` but the original `has` function definition was left in the file, despite no longer being used. This commit delete the orphan `has` function definition.