### PR TITLE
Add ssh-agent setup instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -285,6 +285,10 @@ Per @jefheaton, this is caused when trying to replace an existing `.zshrc` file.
 
 This has been solved by running `zgen update` or switching to [zgenom](https://github.com/jandamm/zgenom). New users of the kit should already be running `zgenom`. Thanks @RonanJackson for reporting the fix.
 
+### Could not open a connection to your authentication agent
+
+Confirm that `ssh-agent` is running. If not, Rob Montero has a good [blog post](https://rob.cr/blog/using-ssh-agent-mac-os-x/) on setting up `ssh-agent` on macOS, and here are [instructions](https://wiki.archlinux.org/title/SSH_keys#Start_ssh-agent_with_systemd_user) for starting `ssh-agent` with `systemd` on Linux.
+
 ## Other Resources
 
 ### ZSH


### PR DESCRIPTION
Add setup instructions for macOS and linux for `ssh-agent`.

Closes https://github.com/unixorn/zsh-quickstart-kit/issues/133

