### PR TITLE
Remove stale .zshrc.local support

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -15,10 +15,10 @@ name: Lint Code Base
 #############################
 on:
   push:
-    branches-ignore: [master]
-    # Remove the line above to run when pushing to master
+    branches-ignore: [main]
+    # Remove the line above to run when pushing to main
   pull_request:
-    branches: [master]
+    branches: [main]
 
 ###############
 # Set the Job #
@@ -50,5 +50,5 @@ jobs:
         uses: github/super-linter@v3
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -344,13 +344,6 @@ if [[ -d ~/.zsh-completions ]]; then
   done
 fi
 
-# Honor old .zshrc.local customizations, but print deprecation warning.
-if [ -f ~/.zshrc.local ]; then
-  source ~/.zshrc.local
-  echo '~/.zshrc.local is deprecated - use files in ~/.zshrc.d instead.'
-  echo 'The zsh-quickstart-kit will no longer load ~/.zshrc.local after 2021-10-31'
-fi
-
 # Load zmv
 if [[ ! -f ~/.zsh-quickstart-no-zmv ]]; then
   autoload -U zmv


### PR DESCRIPTION
- We've been printing a deprecation warning to use a file inside `.zshrc.d` for six months, remove the load of `.zshrc.local`
- Update `superlinter` configuration now that the default branch has been renamed to `main`