### PR TITLE
Add a `zqs` command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -210,7 +210,11 @@ Make a file in `~/.zshrc.d` named something like `999-reset-aliases`. Since thos
 
 ### ZSH options
 
-The quickstart kit does an opinionated (i.e. my way) setup of ZSH options and adds some functions and aliases I like on my systems. However, `~/.zshrc.d` is processed _after_ the quickstart sets its aliases, functions and ZSH options, so if you don't care for something as set up in the quickstart, you can override the offending item in a shell fragment file there.
+The quickstart kit does an opinionated (i.e. my way) setup of ZSH options and adds some functions and aliases I like on my systems.
+
+However, `~/.zshrc.d` is processed _after_ the quickstart sets its aliases, functions and ZSH options, so if you don't care for something as set up in the quickstart, you can override the offending item in a shell fragment file there.
+
+As of 2021-11-13, I've added a `zqs` command to start exposing some of the tunables in a more user-friendly way.
 
 ### Self-update Settings
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -430,7 +430,7 @@ _check-for-zsh-quickstart-update() {
 
 if [[ ! -z "$QUICKSTART_KIT_REFRESH_IN_DAYS" ]]; then
   _check-for-zsh-quickstart-update
-  unset QUICKSTART_KIT_REFRESH_IN_DAYS
+  # unset QUICKSTART_KIT_REFRESH_IN_DAYS
 fi
 
 # Fix bracketed paste issue
@@ -472,3 +472,26 @@ if ! can_haz fzf; then
   echo
   echo "Install instructions can be found at https://github.com/junegunn/fzf/"
 fi
+
+function zqs-help() {
+  echo "The zqs command allows you to manipulate your ZSH quickstart."
+  echo
+  echo "options:"
+  echo "zqs check-for-updates - Update the quickstart kit if it has been longer than $QUICKSTART_KIT_REFRESH_IN_DAYS days since the last update."
+  echo "zqs selfupdate - Force an immediate update of the quickstart kit"
+}
+
+function zqs() {
+  case "$1" in
+    'check-for-updates')
+      _check-for-zsh-quickstart-update
+      ;;
+    'selfupdate')
+      _update-zsh-quickstart
+      ;;
+    *)
+      zqs-help
+      ;;
+
+  esac
+}


### PR DESCRIPTION
Start adding a `zqs` command to make controlling the kit a little less painful for end users.

- Add `zqs check-for-updates` command
- Add `zqs selfupdate` command

Closes #139 