### PR TITLE
oh-my-zsh has deprecated old osx plugin

### DIFF
--- a/.zsh-quickstart-local-plugins-example
+++ b/.zsh-quickstart-local-plugins-example
@@ -114,7 +114,7 @@ if [[ ! -f ~/.zsh-quickstart-no-omz ]]; then
   if [[ $(uname -a | grep -ci Darwin) = 1 ]]; then
     # Load macOS-specific plugins
     zgenom oh-my-zsh plugins/brew
-    zgenom oh-my-zsh plugins/osx
+    zgenom oh-my-zsh plugins/macos
   fi
 
 fi

--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -145,7 +145,7 @@ load-starter-plugin-list() {
     if [ $(uname -a | grep -ci Darwin) = 1 ]; then
       # Load macOS-specific plugins
       zgenom oh-my-zsh plugins/brew
-      zgenom oh-my-zsh plugins/osx
+      zgenom oh-my-zsh plugins/macos
     fi
   fi
 


### PR DESCRIPTION
Update our plugin list. - the `osx` plugin has been deprecated/renamed in favor of `macos`.

Closes #152

Signed-off-by: Joe Block <jpb@unixorn.net>