### PR TITLE
Use exa instead of ls when present

### DIFF
--- a/zsh/.zsh_aliases
+++ b/zsh/.zsh_aliases
@@ -42,6 +42,12 @@ if (( $+commands[gls] )); then
   alias la='gls -A --color'
 fi
 
+# When present, use exa instead of ls
+if canhaz exa; then
+  alias l='exa -al --git --time-style=long-iso --group-directories-first --color-scale'
+  alias ls='exa --group-directories-first'
+fi
+
 export CVS_RSH=ssh
 
 # shellcheck disable=SC2142

--- a/zsh/.zsh_aliases
+++ b/zsh/.zsh_aliases
@@ -44,8 +44,17 @@ fi
 
 # When present, use exa instead of ls
 if canhaz exa; then
+  if [[ -z "$EXA_TREE_IGNORE" ]]; then
+    EXA_TREE_IGNORE=".cache|cache|node_modules|vendor"
+  fi
+
   alias l='exa -al --git --time-style=long-iso --group-directories-first --color-scale'
   alias ls='exa --group-directories-first'
+
+  # Don't step on system-installed tree command
+  if ! canhaz tree; then
+    alias tree='exa --tree'
+  fi
 fi
 
 export CVS_RSH=ssh


### PR DESCRIPTION
- If `exa` is installed, use it instead of `ls`.
- Set `EXA_TREE_IGNORE` if the user doesn't already have it set up
- Add `tree` alias to use `exa` if there isn't already a system-installed `tree` command.