### PR TITLE
Allow 502s during link checking

### DIFF
--- a/.github/workflows/awesomebot.yml
+++ b/.github/workflows/awesomebot.yml
@@ -15,4 +15,4 @@ jobs:
     - uses: actions/checkout@v1
     - uses: docker://dkhamsing/awesome_bot:latest
       with:
-        args: /github/workspace/Readme.md  --allow-dupe --request-delay 1 --allow-redirect --white-list https://ipfs.io,slideshare,https://img.shields.io
+        args: /github/workspace/Readme.md --allow 502 --allow-dupe --request-delay 1 --allow-redirect --white-list https://ipfs.io,slideshare,https://img.shields.io


### PR DESCRIPTION
Github occasionally pukes up 502 errors for good links when awesomebot is checking the links in readme.md, even with the check interval set to 1 second.

Ignore the 502s, if there's a real issue it'll get found in the next test run and this makes it easier to see if there's a real problem.