### PR TITLE
Stop ignoring main branch in superlinter

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -15,7 +15,7 @@ name: Lint Code Base
 #############################
 on:
   push:
-    branches-ignore: [main]
+    branches-ignore: [master]
     # Remove the line above to run when pushing to main
   pull_request:
     branches: [main]


### PR DESCRIPTION
This should hopefully fix the badge in `Readme.md`
