### PR TITLE
Start work on standardizing settings reads

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -43,8 +43,45 @@ if [[ -r ~/.powerlevel9k_font_mode ]]; then
   POWERLEVEL9K_MODE=$(head -1 ~/.powerlevel9k_font_mode)
 fi
 
-# Uncomment following line if you want red dots to be displayed while waiting for completion
+# Unset COMPLETION_WAITING_DOTS in a file in ~/.zshrc.d if you want red dots to be displayed while waiting for completion
 export COMPLETION_WAITING_DOTS="true"
+
+# Provide a unified way for the quickstart to get/set settings.
+if [[ -f ~/.zqs-settings-path ]]; then
+  _ZQS_SETTINGS_DIR=$(cat ~/.zqs-settings-path)
+else
+  _ZQS_SETTINGS_DIR="${HOME}/.zqs-settings"
+fi
+export _ZQS_SETTINGS_DIR
+
+# Settings names have to be valid file names, and we're not doing any parsing here.
+_zqs-get-setting-value() {
+  local sfile="${_ZQS_SETTINGS_DIR}/${1}"
+  if [[ -f "$sfile" ]]; then
+    svalue=$(cat "$sfile")
+  else
+    if [[ $# -eq 2 ]]; then
+      svalue=$2
+    else
+      svalue=''
+    fi
+  fi
+  echo "$svalue"
+}
+
+_zqs-set-setting-value() {
+  if [[ $# -eq 2 ]]; then
+    mkdir -p "$_ZQS_SETTINGS_DIR"
+    echo "$2" > "${_ZQS_SETTINGS_DIR}/$1"
+  else
+    echo "Usage _zqs-set-setting-value SETTINGNAME VALUE"
+  fi
+}
+
+_zqs-purge-setting-value() {
+  local sfile="${_ZQS_SETTINGS_DIR}/${1}"
+  rm -f "$sfile"
+}
 
 # Correct spelling for commands
 setopt correct


### PR DESCRIPTION
# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `_zqs-get-setting-value`, `_zqs-set-setting-value` and `_zqs-purge-setting-value` functions. This is part one of implementing #189 

Next step is to update all the random settings files `zqs` writes to toggle features to use these settings functions

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [ ] Bug fix
- [x] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
