### PR TITLE
Add `.zshrc.pre-plugins.d` directory handling

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -235,7 +235,7 @@ Updates all your plugins.
 
 #### Customizing with ~/.zshrc.d
 
-The `.zshrc` included in this kit will automatically source any files it finds in `~/.zshrc.d`.
+The `.zshrc` included in this kit will automatically source any files it finds in `~/.zshrc.d`. This happens after plugins are loaded. If you need to set variables or aliases before plugins are loaded, create files in `~/.zshrc.pre-plugins.d`.
 
 This makes it easy for you to add extra functions and aliases without having to maintain a separate fork of this repository and allows you to configure the behavior of some of the plugins by setting environment variables.
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -14,7 +14,8 @@
 # Version 1.0.0
 #
 # If you want to change settings that are in this file, the easiest way
-# to do it is by adding a file to ~/.zshrc.d that redefines the sttings.
+# to do it is by adding a file to ~/.zshrc.d or ~/.zshrc.pre-plugins.d that
+# redefines the settings.
 #
 # All files in there will be sourced, and keeping your customizations
 # there will keep you from having to maintain a separate fork of the
@@ -257,9 +258,23 @@ if [[ -z "$SSH_CLIENT" ]] || can_haz keychain; then
   load-our-ssh-keys
 fi
 
-# Load helper functions before we load zgen setup
+# Load helper functions before we load zgenom setup
 if [ -r ~/.zsh_functions ]; then
   source ~/.zsh_functions
+fi
+
+# Make it easy to prepend your own customizations that override the
+# quickstart's defaults by loading all files from the
+# ~/.zshrc.pre-plugins.d directory
+mkdir -p ~/.zshrc.pre-plugins.d
+if [ -n "$(/bin/ls -A ~/.zshrc.pre-plugins.d)" ]; then
+  for _zqs_fragment in $(/bin/ls -A ~/.zshrc.pre-plugins.d)
+  do
+    if [ -r ~/.zshrc.pre-plugins.d/$_zqs_fragment ]; then
+      source ~/.zshrc.pre-plugins.d/$_zqs_fragment
+    fi
+  done
+  unset $_zqs_fragment
 fi
 
 # Now that we have $PATH set up and ssh keys loaded, configure zgenom.
@@ -482,12 +497,13 @@ fi
 # quickstart's defaults by loading all files from the ~/.zshrc.d directory
 mkdir -p ~/.zshrc.d
 if [ -n "$(/bin/ls -A ~/.zshrc.d)" ]; then
-  for dotfile in $(/bin/ls -A ~/.zshrc.d)
+  for _zqs_fragment in $(/bin/ls -A ~/.zshrc.d)
   do
-    if [ -r ~/.zshrc.d/$dotfile ]; then
-      source ~/.zshrc.d/$dotfile
+    if [ -r ~/.zshrc.d/$_zqs_fragment ]; then
+      source ~/.zshrc.d/$_zqs_fragment
     fi
   done
+  unset _zqs_fragment
 fi
 
 # If GOPATH is defined, add it to $PATH


### PR DESCRIPTION

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

<!--- Provide a general summary of your changes in the Title above -->

## Description

We now load shell fragments from the `.zshrc.pre-plugins.d` directory before we start loading plugins.

This is to allow users to set environment variables that control the behavior of their custom plugins before the plugins are loaded.

Enables easy workarounds for #180


## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [ ] Bug fix
- [x] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
