### PR TITLE
Enable `bindkey` and alias expansion configuration.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,8 @@
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
 <!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->
 
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have updated the readme if this PR changes/updates quickstart functionality.
 - [ ] All new and existing tests pass.
 - [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
 - [ ] Scripts are marked executable
@@ -32,4 +34,3 @@
 - [ ] I have added a credit line to README.md for the script
 - [ ] If there was no author credit in a script added in this PR, I have added one.
 - [ ] I have confirmed that the link(s) in my PR are valid.
-- [ ] I have read the **CONTRIBUTING** document.

--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,8 @@
   - [Behavior toggles](#behavior-toggles)
     - [zqs](#zqs)
       - [zqs check-for-updates](#zqs-check-for-updates)
+      - [zqs-disable-bindkey-handling](#zqs-disable-bindkey-handling)
+      - [zqs-enable-bindkey-handling](#zqs-enable-bindkey-handling)
       - [zqs disable-omz-plugins](#zqs-disable-omz-plugins)
       - [zqs enable-omz-plugins](#zqs-enable-omz-plugins)
       - [zqs selfupdate](#zqs-selfupdate)
@@ -211,9 +213,16 @@ As of 2021-11-13, I've added a `zqs` command to start exposing some of the confi
 
 Updates the quickstart kit if it has been longer than seven days since the last update.
 
+##### zqs-disable-bindkey-handling
+
+Disable `bindkey` setup and alias expansion in the quickstart `.zshrc` so people can use plugins like [globalias](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/globalias) to handle it instead.
+
+##### zqs-enable-bindkey-handling
+
+Let the quickstart's `.zshrc` configure `bindkey` setup and alias expansion. This is the default behavior.
 ##### zqs disable-omz-plugins
 
-Sets the quickstart to not include any oh-my-zsh plugins from the standard plugin list. Loading omz plugins can make terminal startup significantly slower.
+Set the quickstart to not include any oh-my-zsh plugins from the standard plugin list. Loading omz plugins can make terminal startup significantly slower.
 
 ##### zqs enable-omz-plugins
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -123,6 +123,17 @@ function zsh-quickstart-select-powerlevel10k() {
   _zqs-trigger-init-rebuild
 }
 
+# Binary feature settings functions should always be named
+# zsh-quickstart-disable-FEATURE and zsh-quickstart-enable-FEATURE
+
+function zsh-quickstart-disable-bindkey-handling() {
+  _zqs-set-setting handle-bindkeys false
+}
+
+function zsh-quickstart-enable-bindkey-handling() {
+  _zqs-set-setting handle-bindkeys true
+}
+
 function zsh-quickstart-disable-omz-plugins() {
   rm -f ~/.zsh-quickstart-no-omz
   _zqs-set-setting load-omz-plugins false
@@ -346,20 +357,22 @@ QUICKSTART_KIT_REFRESH_IN_DAYS=7
 # does a zgen update. Closes #62.
 DISABLE_AUTO_UPDATE=true
 
-# Expand aliases inline - see http://blog.patshead.com/2012/11/automatically-expaning-zsh-global-aliases---simplified.html
-globalias() {
-   if [[ $LBUFFER =~ ' [A-Z0-9]+$' ]]; then
-     zle _expand_alias
-     zle expand-word
-   fi
-   zle self-insert
-}
+if [[ $(_zqs-get-setting handle-bindkeys true) == 'true' ]]; then
+  # Expand aliases inline - see http://blog.patshead.com/2012/11/automatically-expaning-zsh-global-aliases---simplified.html
+  globalias() {
+    if [[ $LBUFFER =~ ' [A-Z0-9]+$' ]]; then
+      zle _expand_alias
+      zle expand-word
+    fi
+    zle self-insert
+  }
 
-zle -N globalias
+  zle -N globalias
 
-bindkey " " globalias
-bindkey "^ " magic-space           # control-space to bypass completion
-bindkey -M isearch " " magic-space # normal space during searches
+  bindkey " " globalias
+  bindkey "^ " magic-space           # control-space to bypass completion
+  bindkey -M isearch " " magic-space # normal space during searches
+fi
 
 # Make it easier to customize the quickstart to your needs without
 # having to maintain your own fork.
@@ -636,19 +649,29 @@ fi
 function zqs-help() {
   echo "The zqs command allows you to manipulate your ZSH quickstart."
   echo
-  echo "options:"
+  echo "Quickstart action commands:"
   echo "zqs check-for-updates - Update the quickstart kit if it has been longer than $QUICKSTART_KIT_REFRESH_IN_DAYS days since the last update."
-  echo "zqs disable-omz-plugins - Set the quickstart to not load oh-my-zsh plugins if you're using the standard plugin list"
-  echo "zqs enable-omz-plugins - Set the quickstart to load oh-my-zsh plugins if you're using the standard plugin list"
   echo "zqs selfupdate - Force an immediate update of the quickstart kit"
   echo "zqs update - Update the quickstart kit and all your plugins"
   echo "zqs update-plugins - Update your plugins"
+  echo ""
+  echo "Quickstart settings commands:"
+  echo "zqs disable-bindkey-handling - Set the quickstart to not touch any bindkey settings. Useful if you're using another plugin to handle it."
+  echo "zqs enable-bindkey-handling - Set the quickstart to confingure your bindkey settings. Default behavior."
+  echo "zqs disable-omz-plugins - Set the quickstart to not load oh-my-zsh plugins if you're using the standard plugin list"
+  echo "zqs enable-omz-plugins - Set the quickstart to load oh-my-zsh plugins if you're using the standard plugin list"
 }
 
 function zqs() {
   case "$1" in
     'check-for-updates')
       _check-for-zsh-quickstart-update
+      ;;
+    'disable-bindkey-handling')
+      zsh-quickstart-disable-bindkey-handling
+      ;;
+    'enable-bindkey-handling')
+      zsh-quickstart-enable-bindkey-handling
       ;;
     'disable-omz-plugins')
       zsh-quickstart-disable-omz-plugins


### PR DESCRIPTION
# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow users to enable/disable `bindkey` and alias expansion with `zqs-enable-bindkey-handling` and `zqs-disable-bindkey-handling`.

Closes #196


## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [x] Bug fix
- [x] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
