### PR TITLE
Add zqs settings helper commands

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -240,6 +240,18 @@ Update the quickstart kit and all your plugins.
 
 Updates all your plugins.
 
+##### zqs get-setting
+
+`zqs get-setting NAME [OPTIONAL default value]` prints the value of a `zqs` setting, or if unset and a default value was passed, the specified default.
+
+##### zs set-setting
+
+`zqs set-setting NAME VALUE` writes a setting.
+
+##### zs delete-setting
+
+`zqs delete-setting NAME` deletes a setting from `zqs`'s crude parameter store.
+
 ### Functions and Aliases
 
 #### Customizing with ~/.zshrc.d

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -661,6 +661,7 @@ function zqs-help() {
   echo "zqs disable-omz-plugins - Set the quickstart to not load oh-my-zsh plugins if you're using the standard plugin list"
   echo "zqs enable-omz-plugins - Set the quickstart to load oh-my-zsh plugins if you're using the standard plugin list"
   echo "zqs get-setting SETTINGNAME [optional default value] - load a zqs setting"
+  echo "zqs set-setting SETTINGNAME value - Set an arbitrary zqs setting"
 }
 
 function zqs() {
@@ -693,6 +694,10 @@ function zqs() {
     'get-setting')
       shift
       _zqs-get-setting $@
+      ;;
+    'set-setting')
+      shift
+      _zqs-set-setting $@
       ;;
     *)
       zqs-help

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -110,6 +110,18 @@ _zqs-set-setting() {
   fi
 }
 
+_zqs-delete-setting(){
+  # We want to keep output clean when settings are cleared internally, so
+  # use a separate function when called by a human we can display a warning
+  # if the setting doesn't exist.
+  local sfile="${_ZQS_SETTINGS_DIR}/${1}"
+  if [[ -f "$sfile" ]]; then
+    rm -f "$sfile"
+  else
+    echo "There is no settings file for ${1}"
+  fi
+}
+
 _zqs-purge-setting() {
   local sfile="${_ZQS_SETTINGS_DIR}/${1}"
   rm -f "$sfile"
@@ -660,6 +672,7 @@ function zqs-help() {
   echo "zqs enable-bindkey-handling - Set the quickstart to confingure your bindkey settings. Default behavior."
   echo "zqs disable-omz-plugins - Set the quickstart to not load oh-my-zsh plugins if you're using the standard plugin list"
   echo "zqs enable-omz-plugins - Set the quickstart to load oh-my-zsh plugins if you're using the standard plugin list"
+  echo "zqs delete-setting SETTINGNAME - Remove a zqs setting file"
   echo "zqs get-setting SETTINGNAME [optional default value] - load a zqs setting"
   echo "zqs set-setting SETTINGNAME value - Set an arbitrary zqs setting"
 }
@@ -691,6 +704,9 @@ function zqs() {
     'update-plugins')
       zgenom update
       ;;
+    'delete-setting')
+      shift
+      _zqs-delete-setting $@
     'get-setting')
       shift
       _zqs-get-setting $@

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -421,6 +421,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   if [ -d ~/.macos_aliases.d ]; then
     load-shell-fragments ~/.macos_aliases.d
   fi
+
   # Keep supporting the old name, but emit a deprecation warning
   [ -r ~/.osx_aliases ] && source ~/.osx_aliases
   if [ -d ~/.osx_aliases.d ]; then
@@ -659,6 +660,7 @@ function zqs-help() {
   echo "zqs enable-bindkey-handling - Set the quickstart to confingure your bindkey settings. Default behavior."
   echo "zqs disable-omz-plugins - Set the quickstart to not load oh-my-zsh plugins if you're using the standard plugin list"
   echo "zqs enable-omz-plugins - Set the quickstart to load oh-my-zsh plugins if you're using the standard plugin list"
+  echo "zqs get-setting SETTINGNAME [optional default value] - load a zqs setting"
 }
 
 function zqs() {
@@ -687,6 +689,10 @@ function zqs() {
       ;;
     'update-plugins')
       zgenom update
+      ;;
+    'get-setting')
+      shift
+      _zqs-get-setting $@
       ;;
     *)
       zqs-help


### PR DESCRIPTION
# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds `zqs get-setting`, `zqs set-setting` and `zqs delete-setting` commands. 

Closes #207 

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [ ] Bug fix
- [x] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the readme if this PR changes/updates quickstart functionality.
- [ ] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
