### PR TITLE
Keep omz from complaining when `python` is not in `$PATH`

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -315,6 +315,14 @@ fi
 mkdir -p ~/.zshrc.pre-plugins.d
 load-shell-fragments ~/.zshrc.pre-plugins.d
 
+# macOS doesn't have a python by default. This makes the omz python plugin
+# sad, so if there isn't a python, alias it to python3
+if ! can_haz python; then
+  if can_haz python3; then
+    alias python=python3
+  fi
+fi
+
 # Now that we have $PATH set up and ssh keys loaded, configure zgenom.
 # Start zgenom
 if [ -f ~/.zgen-setup ]; then


### PR DESCRIPTION


# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

<!--- Provide a general summary of your changes in the Title above -->

## Description

If there is still no `python` in `$PATH` after loading `~/.zshrc.pre.d`, we alias it to `python3` to keep omz from complaining.

Closes #180

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [x] Bug fix
- [ ] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the readme if this PR changes/updates quickstart functionality.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
