### PR TITLE
Add more `zqs enable|disable` commands

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,11 +27,16 @@
       - [zqs check-for-updates](#zqs-check-for-updates)
       - [zqs-disable-bindkey-handling](#zqs-disable-bindkey-handling)
       - [zqs-enable-bindkey-handling](#zqs-enable-bindkey-handling)
+      - [zqs-disable-ssh-key-listing](#zqs-disable-ssh-key-listing)
+      - [zqs-enable-ssh-key-listing](#zqs-enable-ssh-key-listing)
       - [zqs disable-omz-plugins](#zqs-disable-omz-plugins)
       - [zqs enable-omz-plugins](#zqs-enable-omz-plugins)
       - [zqs selfupdate](#zqs-selfupdate)
       - [zqs update](#zqs-update)
       - [zqs update-plugins](#zqs-update-plugins)
+      - [zqs get-setting](#zqs-get-setting)
+      - [zqs set-setting](#zqs-set-setting)
+      - [zqs delete-setting](#zqs-delete-setting)
   - [Functions and Aliases](#functions-and-aliases)
     - [Customizing with ~/.zshrc.d](#customizing-with-zshrcd)
   - [I like a plugin, but some of the aliases and functions it installs overwrite other commands or aliases I use](#i-like-a-plugin-but-some-of-the-aliases-and-functions-it-installs-overwrite-other-commands-or-aliases-i-use)
@@ -42,6 +47,7 @@
   - [Disabling oh-my-zsh](#disabling-oh-my-zsh)
 - [FAQ](#faq)
   - [How do I reconfigure the prompt?](#how-do-i-reconfigure-the-prompt)
+  - [Powerlevel 10k warns that there is console output during startup](#powerlevel-10k-warns-that-there-is-console-output-during-startup)
   - [I added a new completion plugin, and it isn't working](#i-added-a-new-completion-plugin-and-it-isnt-working)
   - [I get a git error when I try to update the kit](#i-get-a-git-error-when-i-try-to-update-the-kit)
   - [GNU stow is warning that stowing zsh would cause conflicts](#gnu-stow-is-warning-that-stowing-zsh-would-cause-conflicts)
@@ -220,6 +226,15 @@ Disable `bindkey` setup and alias expansion in the quickstart `.zshrc` so people
 ##### zqs-enable-bindkey-handling
 
 Let the quickstart's `.zshrc` configure `bindkey` setup and alias expansion. This is the default behavior.
+
+##### zqs-disable-ssh-key-listing
+
+Don't print the loaded `ssh` keys when creating a new session.
+
+##### zqs-enable-ssh-key-listing
+
+Print the loaded `ssh` keys when creating a new session. This is the default behavior.
+
 ##### zqs disable-omz-plugins
 
 Set the quickstart to not include any oh-my-zsh plugins from the standard plugin list. Loading omz plugins can make terminal startup significantly slower.
@@ -244,11 +259,11 @@ Updates all your plugins.
 
 `zqs get-setting NAME [OPTIONAL default value]` prints the value of a `zqs` setting, or if unset and a default value was passed, the specified default.
 
-##### zs set-setting
+##### zqs set-setting
 
 `zqs set-setting NAME VALUE` writes a setting.
 
-##### zs delete-setting
+##### zqs delete-setting
 
 `zqs delete-setting NAME` deletes a setting from `zqs`'s crude parameter store.
 

--- a/Readme.md
+++ b/Readme.md
@@ -302,7 +302,7 @@ Copy that to your `$HOME/.zsh-quickstart-local-plugins`, change the list, and th
 
 ### Disabling zmv
 
-The quickstart automatically autoloads `zmv`. If you want to disable that, create a file named `.zsh-quickstart-no-zmv` in your home directory.
+The quickstart automatically autoloads `zmv`. If you want to disable that so you can configure it with another plugin or on your own, run `zqs disable-zmv-autoloading`.
 
 ### Disabling oh-my-zsh
 

--- a/Readme.md
+++ b/Readme.md
@@ -27,10 +27,12 @@
       - [zqs check-for-updates](#zqs-check-for-updates)
       - [zqs-disable-bindkey-handling](#zqs-disable-bindkey-handling)
       - [zqs-enable-bindkey-handling](#zqs-enable-bindkey-handling)
-      - [zqs-disable-ssh-key-listing](#zqs-disable-ssh-key-listing)
-      - [zqs-enable-ssh-key-listing](#zqs-enable-ssh-key-listing)
       - [zqs disable-omz-plugins](#zqs-disable-omz-plugins)
       - [zqs enable-omz-plugins](#zqs-enable-omz-plugins)
+      - [zqs-disable-ssh-key-listing](#zqs-disable-ssh-key-listing)
+      - [zqs-enable-ssh-key-listing](#zqs-enable-ssh-key-listing)
+      - [zqs-disable-zmv-autoloading](#zqs-disable-zmv-autoloading)
+      - [zqs-enable-zmv-autoloading](#zqs-enable-zmv-autoloading)
       - [zqs selfupdate](#zqs-selfupdate)
       - [zqs update](#zqs-update)
       - [zqs update-plugins](#zqs-update-plugins)
@@ -227,6 +229,14 @@ Disable `bindkey` setup and alias expansion in the quickstart `.zshrc` so people
 
 Let the quickstart's `.zshrc` configure `bindkey` setup and alias expansion. This is the default behavior.
 
+##### zqs disable-omz-plugins
+
+Set the quickstart to not include any oh-my-zsh plugins from the standard plugin list. Loading omz plugins can make terminal startup significantly slower.
+
+##### zqs enable-omz-plugins
+
+Sets the quickstart to include the oh-my-zsh plugins from the standard plugin list.
+
 ##### zqs-disable-ssh-key-listing
 
 Don't print the loaded `ssh` keys when creating a new session.
@@ -235,13 +245,13 @@ Don't print the loaded `ssh` keys when creating a new session.
 
 Print the loaded `ssh` keys when creating a new session. This is the default behavior.
 
-##### zqs disable-omz-plugins
+##### zqs-disable-zmv-autoloading
 
-Set the quickstart to not include any oh-my-zsh plugins from the standard plugin list. Loading omz plugins can make terminal startup significantly slower.
+Don't run `autoload -U zmv` when creating a new session.
 
-##### zqs enable-omz-plugins
+##### zqs-enable-zmv-autoloading
 
-Sets the quickstart to include the oh-my-zsh plugins from the standard plugin list.
+Run `autoload -U zmv` when creating a new session. This is the default behavior.
 
 ##### zqs selfupdate
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -668,7 +668,7 @@ else
   source ~/.p10k.zsh
 fi
 
-if [[ -z "$DONT_PRINT_SSH_KEY_LIST" ]]; then
+if [[ $(_zqs-get-setting list-ssh-keys true) == 'true' ]]; then
   echo
   echo "Current SSH Keys:"
   ssh-add -l
@@ -708,6 +708,8 @@ function zqs-help() {
   echo "zqs enable-bindkey-handling - Set the quickstart to confingure your bindkey settings. Default behavior."
   echo "zqs disable-omz-plugins - Set the quickstart to not load oh-my-zsh plugins if you're using the standard plugin list"
   echo "zqs enable-omz-plugins - Set the quickstart to load oh-my-zsh plugins if you're using the standard plugin list"
+  echo "zqs disable-ssh-key-listing - Set the quickstart to not display all the loaded ssh keys"
+  echo "zqs enable-ssh-key-listing - Set the quickstart to display all the loaded ssh keys. Default behavior."
   echo "zqs disable-zmv-autoloading - Set the quickstart to not run 'autoload -U zmv'. Useful if you're using another plugin to handle it."
   echo "zqs enable-zmv-autoloading - Set the quickstart to run 'autoload -U zmv'. Default behavior."
   echo "zqs delete-setting SETTINGNAME - Remove a zqs setting file"
@@ -737,6 +739,12 @@ function zqs() {
       ;;
     'enable-omz-plugins')
       zsh-quickstart-enable-omz-plugins
+      ;;
+    'enable-ssh-key-listing')
+      _zqs-set-setting list-ssh-keys true
+      ;;
+    'disable-ssh-key-listing')
+      _zqs-set-setting list-ssh-keys false
       ;;
     'selfupdate')
       _update-zsh-quickstart

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -132,14 +132,20 @@ function _zqs-update-stale-settings-files() {
   if [[ -f ~/.zsh-quickstart-use-bullet-train ]]; then
     _zqs-set-setting bullet-train true
     rm -f ~/.zsh-quickstart-use-bullet-train
-    echo "Converted old ~/.zsh-quickstart-use-bullet-train to new settings format"
+    echo "Converted old ~/.zsh-quickstart-use-bullet-train to new settings system"
   fi
   if [[ -f ~/.zsh-quickstart-no-omz ]]; then
     _zqs-set-setting load-omz-plugins false
     rm -f ~/.zsh-quickstart-no-omz
-    echo "Converted old ~/.zsh-quickstart-no-omz to new settings format"
+    echo "Converted old ~/.zsh-quickstart-no-omz to new settings system"
+  fi
+  if [[ -f ~/.zsh-quickstart-no-zmv ]]; then
+    _zqs-set-setting no-zmv true
+    rm -f ~/.zsh-quickstart-no-zmv
+    echo "Converted old ~/.zsh-quickstart-no-zmv to new settings system"
   fi
 }
+
 _zqs-update-stale-settings-files
 
 # Add some quickstart feature toggle functions
@@ -165,6 +171,14 @@ function zsh-quickstart-disable-bindkey-handling() {
 
 function zsh-quickstart-enable-bindkey-handling() {
   _zqs-set-setting handle-bindkeys true
+}
+
+function _zqs-enable-zmv-autoloading() {
+  _zqs-set-setting no-zmv false
+}
+
+function _zqs-disable-zmv-autoloading() {
+  _zqs-set-setting no-zmv true
 }
 
 function zsh-quickstart-disable-omz-plugins() {
@@ -544,7 +558,7 @@ if [[ -d ~/.zsh-completions ]]; then
 fi
 
 # Load zmv
-if [[ ! -f ~/.zsh-quickstart-no-zmv ]]; then
+if [[ $(_zqs-get-setting no-zmv false) == 'false' ]]; then
   autoload -U zmv
 fi
 
@@ -694,6 +708,8 @@ function zqs-help() {
   echo "zqs enable-bindkey-handling - Set the quickstart to confingure your bindkey settings. Default behavior."
   echo "zqs disable-omz-plugins - Set the quickstart to not load oh-my-zsh plugins if you're using the standard plugin list"
   echo "zqs enable-omz-plugins - Set the quickstart to load oh-my-zsh plugins if you're using the standard plugin list"
+  echo "zqs disable-zmv-autoloading - Set the quickstart to not run 'autoload -U zmv'. Useful if you're using another plugin to handle it."
+  echo "zqs enable-zmv-autoloading - Set the quickstart to run 'autoload -U zmv'. Default behavior."
   echo "zqs delete-setting SETTINGNAME - Remove a zqs setting file"
   echo "zqs get-setting SETTINGNAME [optional default value] - load a zqs setting"
   echo "zqs set-setting SETTINGNAME value - Set an arbitrary zqs setting"
@@ -709,6 +725,12 @@ function zqs() {
       ;;
     'enable-bindkey-handling')
       zsh-quickstart-enable-bindkey-handling
+      ;;
+    'disable-zmv-autoloading')
+      _zqs-disable-zmv-autoloading
+      ;;
+    'enable-zmv-autoloading')
+      _zqs-enable-zmv-autoloading
       ;;
     'disable-omz-plugins')
       zsh-quickstart-disable-omz-plugins


### PR DESCRIPTION
# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Convert autoload toggle file in `~` to the new settings system and add `zqs enable-zmv-autoloading` and `zqs disable-zmv-autoloading` commands to toggle it.  Closes #224
- Add `zqs-enable|disable-ssh-key-listing` commands to make it easy for users to not see a listing of loaded `ssh` keys when a new terminal session is started. Closes #227 

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [x] Bug fix
- [ ] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the readme if this PR changes/updates quickstart functionality.
- [ ] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
