### PR TITLE
fixup: ssh-askpass-require

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -193,10 +193,14 @@ function zsh-quickstart-enable-omz-plugins() {
   _zqs-trigger-init-rebuild
 }
 
+function zsh-quickstart-set-ssh-askpass-require() {
+  if [[ $(_zqs-get-setting ssh-askpass-require) == 'true' ]]; then
+    export SSH_ASKPASS_REQUIRE=never
+  fi
+}
+
 function zsh-quickstart-enable-ssh-askpass-require() {
-  zsh-quickstart-check-for-ssh-askpass
   _zqs-set-setting ssh-askpass-require true
-  export SSH_ASKPASS_REQUIRE=never
 }
 
 function zsh-quickstart-disable-ssh-askpass-require() {
@@ -336,7 +340,11 @@ load-our-ssh-keys() {
 
 if [[ -z "$SSH_CLIENT" ]] || can_haz keychain; then
   # We're not on a remote machine, so load keys
-  zsh-quickstart-check-for-ssh-askpass
+  if [[ "$(_zqs-get-setting ssh-askpass-require)" == 'true' ]]; then
+    zsh-quickstart-set-ssh-askpass-require
+  else
+    zsh-quickstart-check-for-ssh-askpass
+  fi
   load-our-ssh-keys
 fi
 


### PR DESCRIPTION
After updating to the latest quickstart release, the `enable-ssh-askpass-require` option didn't work anymore like in my local tests.

Add `zsh-quickstart-set-ssh-askpass-require()` to execute if the: `zqs enable-ssh-askpass-require` has been set in the quickstart.

Refactor the check for sending the warning about a missing `ssh-askpass` application and setting the `SSH_ASKPASS_REQUIRE` variable.

Fixes #229  #233 

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [x] Bug fix
- [ ] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the readme if this PR changes/updates quickstart functionality.
- [ ] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
