### PR TITLE
Initial implementation of 1Password ssh-agent

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -102,14 +102,17 @@ export LSCOLORS='Exfxcxdxbxegedabagacad'
 export LS_COLORS='di=1;34;40:ln=35;40:so=32;40:pi=33;40:ex=31;40:bd=34;46:cd=34;43:su=0;41:sg=0;46:tw=0;42:ow=0;43:'
 
 load-our-ssh-keys() {
-  if [ -z "$SSH_AUTH_SOCK" ]; then
-   # Check for a currently running instance of the agent
-   RUNNING_AGENT="$(ps -ax | grep 'ssh-agent -s' | grep -v grep | wc -l | tr -d '[:space:]')"
-   if [ "$RUNNING_AGENT" = "0" ]; then
-        # Launch a new instance of the agent
-        ssh-agent -s &> ~/.ssh/ssh-agent
-   fi
-   eval $(cat ~/.ssh/ssh-agent)
+  if can_haz op; then export SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock
+  else
+    if [ -z "$SSH_AUTH_SOCK" ]; then
+    # Check for a currently running instance of the agent
+    RUNNING_AGENT="$(ps -ax | grep 'ssh-agent -s' | grep -v grep | wc -l | tr -d '[:space:]')"
+    if [ "$RUNNING_AGENT" = "0" ]; then
+          # Launch a new instance of the agent
+          ssh-agent -s &> ~/.ssh/ssh-agent
+    fi
+    eval $(cat ~/.ssh/ssh-agent)
+    fi
   fi
   # Fun with SSH
   if [ $(ssh-add -l | grep -c "The agent has no identities." ) -eq 1 ]; then


### PR DESCRIPTION
# License Acceptance

- [X ] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

## Description

This is an intital impleemntation of the 1Password ssh-agent to start the conversation on how to implement this correctly.

This code leverages the existing `can_haz` function to check for the 1Password CLI tool `op`. This is a **HUGE** assumption -- so lets talk about it.

However, I wonder if this code even needs to be merged because the user can set the [`SSH_AUTH_SOCK` environment variable](https://developer.1password.com/docs/ssh/get-started#step-4-configure-your-ssh-or-git-client) themselves in their functions file.

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [X ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [ ] Bug fix
- [ X] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [X ] I have read the **CONTRIBUTING** document.
- [ N/A] I have updated the readme if this PR changes/updates quickstart functionality.
- [ ] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
