### PR TITLE
added support for ~/.zqs-additional-plugins

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -322,9 +322,9 @@ I've included what I think is a good starter set of ZSH plugins in this reposito
 
 There are two main ways to customize the list.
 
-You can either add a new plugin in a file in `~/.zshrc.pre-plugins.d`, or you can make a `~/.zsh-quickstart-local-plugin` file.
+You can either add a new plugin to `~/.zqs-additional-plugins`, or you can make a `~/.zsh-quickstart-local-plugin` file.
 
-If you're just adding plugins to the standard list and want to automatically get any new changes I make to that standard list (new plugins, new locations when existing plugins are moved, etc) then adding a file like `/zshrc.pre-plugins.d/999-add-some-plugins` with entries like `zgenom load githubuser/pluginrepo && zgenom save` is the way to go - the kit will load its plugins, then add yours on the end.
+If you're just adding plugins to the standard list and want to automatically get any new changes I make to that standard list (new plugins, new locations when existing plugins are moved, etc) then adding a file called `~/.zqs-additional-plugins` with entries like `githubuser/pluginrepo` is the way to go - the kit will load its plugins, then add yours on the end. The file will be read line by line, and each line passed directly to `zgenom load`.
 
 If you don't care about changes to the kit's plugins, then go with creating a `~/.zsh-quickstart-local-plugin` file.
 

--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -128,6 +128,19 @@ load-starter-plugin-list() {
   # in a repository securely by encrypting them with gnupg.
   zgenom load StackExchange/blackbox
 
+  if [[ -f ~/.zqs-additional-plugins ]]; then
+    readarray ~/.zqs-additional-plugins plugins
+
+    for plugin in $plugins; do
+      zgenom load "$plugin"
+    done
+
+    zgenom save
+
+    unset plugin
+    unset newplugins
+  fi
+
   if [[ ! -f ~/.zsh-quickstart-no-omz ]] || [[ $(_zqs-get-setting load-omz-plugins false) == 'true' ]]; then
     # Load some oh-my-zsh plugins
     zgenom oh-my-zsh plugins/pip

--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -136,8 +136,6 @@ load-starter-plugin-list() {
       zgenom load "$plugin"
     done
 
-    zgenom save
-
     unset plugin
     unset plugins
     unset separator

--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -129,7 +129,8 @@ load-starter-plugin-list() {
   zgenom load StackExchange/blackbox
 
   if [[ -f ~/.zqs-additional-plugins ]]; then
-    readarray ~/.zqs-additional-plugins plugins
+    separator='\n'
+    plugins=(${(ps.$separator.)$(cat ~/.zqs-additional-plugins)})
 
     for plugin in $plugins; do
       zgenom load "$plugin"
@@ -138,7 +139,8 @@ load-starter-plugin-list() {
     zgenom save
 
     unset plugin
-    unset newplugins
+    unset plugins
+    unset separator
   fi
 
   if [[ ! -f ~/.zsh-quickstart-no-omz ]] || [[ $(_zqs-get-setting load-omz-plugins false) == 'true' ]]; then


### PR DESCRIPTION
# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

## Description

I've added support for a `~/.zqs-additional-plugins` file, as scripts in `~/.zshrc.pre-plugins.d/` can't access zgenom. Each line in the file will run directly as `zgenom load "$line"`

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [x] Bug fix
- [ ] New feature
- [ ] Plugin list change

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the readme if this PR changes/updates quickstart functionality.
- [ ] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
