### PR TITLE
Deprecate `ZSH_QUICKSTART_SKIP_TRAPINT`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,8 @@
       - [zqs-disable-bindkey-handling](#zqs-disable-bindkey-handling)
       - [zqs-enable-bindkey-handling](#zqs-enable-bindkey-handling)
       - [zqs disable-omz-plugins](#zqs-disable-omz-plugins)
+      - [zqs enable-control-c-decorator](#zqs-enable-control-c-decorator)
+      - [zqs disable-control-c-decorator](#zqs-disable-control-c-decorator)
       - [zqs enable-omz-plugins](#zqs-enable-omz-plugins)
       - [zqs enable-ssh-askpass-require](#zqs-enable-ssh-askpass-require)
       - [zqs disable-ssh-askpass-require](#zqs-disable-ssh-askpass-require)
@@ -57,6 +59,7 @@
   - [GNU stow is warning that stowing zsh would cause conflicts](#gnu-stow-is-warning-that-stowing-zsh-would-cause-conflicts)
   - [_arguments:comparguments:325: can only be called from completion function](#_argumentscomparguments325-can-only-be-called-from-completion-function)
   - [Could not open a connection to your authentication agent](#could-not-open-a-connection-to-your-authentication-agent)
+  - [I want to pin a plugin version](#i-want-to-pin-a-plugin-version)
 - [Other Resources](#other-resources)
   - [ZSH](#zsh)
   - [Dotfiles in general](#dotfiles-in-general)
@@ -214,7 +217,7 @@ Running the following commands will toggle behavior the next time you start a sh
   * `zsh-quickstart-select-powerlevel10k` -  Switch to the [powerlevel10k](https://github.com/romkatv/powerlevel10k) prompt now used as the kit's default.
   * `zsh-quickstart-select-bullet-train` - Switch back to the [bullet-train](https://github.com/caiogondim/bullet-train.zsh) prompt originally used in the kit.
 * You can disable printing the list of `ssh` keys by executing `zqs disable-ssh-key-listing`.
-* `bash` prints `^C` when you're typing a command and control-c to cancel, so it is easy to see it wasn't executed. By default, ZSH doesn't print the `^C`. I like seeing the `^C`, so by default, the quickstart traps `SIGINT` and prints the `^C`. You can disable this by exporting `ZSH_QUICKSTART_SKIP_TRAPINT='false'` in one of the files in `~/.zshrc.d`.
+* `bash` prints `^C` when you're typing a command and hit control-c to cancel it, so it is easy to see it wasn't executed. By default, ZSH doesn't print the `^C`. I prefer seeing the `^C`, so by default, the quickstart traps `SIGINT` and prints the `^C`. You can disable this behavior by running `zqs enable-control-c-decorator`.
 
 #### zqs
 
@@ -235,6 +238,14 @@ Let the quickstart's `.zshrc` configure `bindkey` setup and alias expansion. Thi
 ##### zqs disable-omz-plugins
 
 Set the quickstart to not include any oh-my-zsh plugins from the standard plugin list. Loading omz plugins can make terminal startup significantly slower.
+
+##### zqs enable-control-c-decorator
+
+Set the quickstart to create a `TRAPINT` handler in future `zsh` sessions to also display control-C when you type control-c. This is the default behavior.
+
+##### zqs disable-control-c-decorator
+
+Set the quickstart to not create the `TRAPINT` handler to display control-C when you type control-c in future `zsh` sessions.
 
 ##### zqs enable-omz-plugins
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -144,6 +144,12 @@ function _zqs-update-stale-settings-files() {
     rm -f ~/.zsh-quickstart-no-zmv
     echo "Converted old ~/.zsh-quickstart-no-zmv to new settings system"
   fi
+  # Don't break existing user setups, but transition to a zqs setting to reduce
+  # pollution in the user's environment.
+  if [[ -z "ZSH_QUICKSTART_SKIP_TRAPINT" ]]; then
+    echo "'ZSH_QUICKSTART_SKIP_TRAPINT' is deprecated in favor of running 'zqs disable-control-c-decorator' to write a settings knob."
+    zqs-quickstart-disable-control-c-decorator
+  fi
 }
 
 _zqs-update-stale-settings-files
@@ -687,13 +693,6 @@ if [[ $(_zqs-get-setting list-ssh-keys true) == 'true' ]]; then
   echo "Current SSH Keys:"
   ssh-add -l
   echo
-fi
-
-# Don't break existing user setups, but transition to a zqs setting to reduce
-# pollution in the user's environment.
-if [[ -z "ZSH_QUICKSTART_SKIP_TRAPINT" ]]; then
-  echo "'ZSH_QUICKSTART_SKIP_TRAPINT' is deprecated in favor of running 'zqs disable-control-c-decorator' to write a settings knob."
-  zqs-quickstart-disable-control-c-decorator
 fi
 
 if [[ $(_zqs-get-setting control-c-decorator 'true') == 'true' ]]; then

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -692,7 +692,7 @@ fi
 # Don't break existing user setups, but transition to a zqs setting to reduce
 # pollution in the user's environment.
 if [[ -z "ZSH_QUICKSTART_SKIP_TRAPINT" ]]; then
-  echo "ZSH_QUICKSTART_SKIP_TRAPINT is deprecated in favor of running 'zqs disable-control-c-decorator' to write a settings knob"
+  echo "'ZSH_QUICKSTART_SKIP_TRAPINT' is deprecated in favor of running 'zqs disable-control-c-decorator' to write a settings knob."
   zqs-quickstart-disable-control-c-decorator
 fi
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -173,6 +173,18 @@ function zsh-quickstart-enable-bindkey-handling() {
   _zqs-set-setting handle-bindkeys true
 }
 
+function zqs-quickstart-disable-control-c-decorator() {
+  _zqs-set-setting control-c-decorator false
+  echo "Disabled the control-c decorator in future zsh sessions."
+  echo "You can re-enable the quickstart's control-c decorator by running 'zqs enable-control-c-decorator'"
+}
+
+function zqs-quickstart-enable-control-c-decorator() {
+  echo "The control-c decorator is enabled for future zsh sessions."
+  echo "You can disable the quickstart's control-c decorator by running 'zqs disable-control-c-decorator'"
+  _zqs-set-setting control-c-decorator true
+}
+
 function _zqs-enable-zmv-autoloading() {
   _zqs-set-setting no-zmv false
 }
@@ -677,7 +689,14 @@ if [[ $(_zqs-get-setting list-ssh-keys true) == 'true' ]]; then
   echo
 fi
 
+# Don't break existing user setups, but transition to a zqs setting to reduce
+# pollution in the user's environment.
 if [[ -z "ZSH_QUICKSTART_SKIP_TRAPINT" ]]; then
+  echo "ZSH_QUICKSTART_SKIP_TRAPINT is deprecated in favor of running 'zqs disable-control-c-decorator' to write a settings knob"
+  zqs-quickstart-disable-control-c-decorator
+fi
+
+if [[ $(_zqs-get-setting control-c-decorator 'true') == 'true' ]]; then
   # Original source: https://vinipsmaker.wordpress.com/2014/02/23/my-zsh-config/
   # bash prints ^C when you're typing a command and control-c to cancel, so it
   # is easy to see it wasn't executed. By default, ZSH doesn't print the ^C.
@@ -707,7 +726,9 @@ function zqs-help() {
   echo ""
   echo "Quickstart settings commands:"
   echo "zqs disable-bindkey-handling - Set the quickstart to not touch any bindkey settings. Useful if you're using another plugin to handle it."
-  echo "zqs enable-bindkey-handling - Set the quickstart to confingure your bindkey settings. Default behavior."
+  echo "zqs enable-bindkey-handling - Set the quickstart to configure your bindkey settings. Default behavior."
+  echo "zqs enable-control-c-decorator - Creates a TRAPINT function to display '^C' when you type control-c instead of being silent. Default behavior."
+  echo "zqs disable-control-c-decorator - No longer creates a TRAPINT function to display '^C' when you type control-c."
   echo "zqs disable-omz-plugins - Set the quickstart to not load oh-my-zsh plugins if you're using the standard plugin list"
   echo "zqs enable-omz-plugins - Set the quickstart to load oh-my-zsh plugins if you're using the standard plugin list"
   echo "zqs enable-ssh-askpass-require - Set the quickstart to prompt for your ssh passphrase on the command line."
@@ -732,6 +753,13 @@ function zqs() {
     'enable-bindkey-handling')
       zsh-quickstart-enable-bindkey-handling
       ;;
+    'disable-control-c-decorator')
+      zqs-quickstart-disable-control-c-decorator
+      ;;
+    'enable-control-c-decorator')
+      zqs-quickstart-enable-control-c-decorator
+      ;;
+
     'disable-zmv-autoloading')
       _zqs-disable-zmv-autoloading
       ;;


### PR DESCRIPTION


# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

<!--- Provide a general summary of your changes in the Title above -->

## Description

For consistency, use `zqs disable-control-c-decorator` to keep the quickstart from displaying `^C` when the user types control-c.

This also reduces pollution in the user's environment variables.

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [ ] Bug fix
- [x] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the readme if this PR changes/updates quickstart functionality.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
