### PR TITLE
call unaliased version ls

### DIFF
--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -297,7 +297,7 @@ elif [ -d ~/.zshrc.add-plugins.d ]; then
       need_update="true"
   fi
 
-  if [[ -n "$(ls -A ~/.zshrc.add-plugins.d)" ]] && [[ -z $need_update ]]; then
+  if [[ -n "$("ls" -A ~/.zshrc.add-plugins.d)" ]] && [[ -z $need_update ]]; then
     for file in ~/.zshrc.add-plugins.d/*; do
       if [[ $(get_file_modification_time "${file}") -gt ${init_timestamp} ]]; then
         need_update="true"


### PR DESCRIPTION
# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

<!--- Provide a general summary of your changes in the Title above -->

## Description

If there is an alias `ls` for the application `exa`, we get an error about the wrong argument `-A` when we run the terminal. This solution fixes the bug

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [x] Bug fix
- [ ] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the readme if this PR changes/updates quickstart functionality.
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have added a credit line to README.md for the script
- [x] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
