### PR TITLE
selfupdate: Recursively resolve symlink

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -631,12 +631,13 @@ _load-lastupdate-from-file() {
 }
 
 _update-zsh-quickstart() {
-  if [[ ! -L ~/.zshrc ]]; then
+  local _zshrc_loc=~/.zshrc
+  if [[ ! -L "${_zshrc_loc}" ]]; then
     echo ".zshrc is not a symlink, skipping zsh-quickstart-kit update"
   else
-    local _link_loc=$(readlink ~/.zshrc);
+    local _link_loc=${_zshrc_loc:A};
     if [[ "${_link_loc/${HOME}}" == "${_link_loc}" ]]; then
-      pushd $(dirname "${HOME}/$(readlink ~/.zshrc)");
+      pushd $(dirname "${HOME}/${_zshrc_loc:A}");
     else
       pushd $(dirname ${_link_loc});
     fi;


### PR DESCRIPTION


# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

<!--- Provide a general summary of your changes in the Title above -->

## Description

[For reasons](https://github.com/matthiasr/profile), my `~/.zshrc` is a symlink to a symlink to the quickstart kit. `readlink` only resolved one layer, causing the self-update mechanism to look at the wrong git repository.

Instead of `readlink`, which does not have portable recursive resolution, use ZSH's native [`:A` modifier][modifiers] to follow all symlinks until we find the real file, then update that.

[modifiers]: https://zsh.sourceforge.io/Doc/Release/Expansion.html#Modifiers
## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [x] Bug fix
- [ ] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the readme if this PR changes/updates quickstart functionality.
- [ ] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have added a credit line to README.md for the script
- [x] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
