### PR TITLE
Fix ssh issue when `op` is found on linux

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -28,7 +28,7 @@ function can_haz() {
 
 # Fix weirdness with intellij
 if [[ -z "${INTELLIJ_ENVIRONMENT_READER}" ]]; then
-    export POWERLEVEL9K_INSTANT_PROMPT='quiet'
+  export POWERLEVEL9K_INSTANT_PROMPT='quiet'
 fi
 
 # Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
@@ -307,26 +307,32 @@ if [[ -z "$LS_COLORS" ]]; then
 fi
 
 load-our-ssh-keys() {
-  if can_haz op; then export SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock
+  if can_haz op; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+      export SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock
+    fi
+    if [[ "$(uname -s)" == "Linux" ]]; then
+      export SSH_AUTH_SOCK=~/.1password
+    fi
   else
     # If keychain is installed let it take care of ssh-agent, else do it manually
-  if can_haz keychain; then
-    eval `keychain -q --eval`
-  else
-    if [ -z "$SSH_AUTH_SOCK" ]; then
-       # If user has keychain installed, let it take care of ssh-agent, else do it manually
-      # Check for a currently running instance of the agent
-       RUNNING_AGENT="$(ps -ax | grep 'ssh-agent -s' | grep -v grep | wc -l | tr -d '[:space:]')"
-       if [ "$RUNNING_AGENT" = "0" ]; then
+    if can_haz keychain; then
+      eval `keychain -q --eval`
+    else
+      if [ -z "$SSH_AUTH_SOCK" ]; then
+        # If user has keychain installed, let it take care of ssh-agent, else do it manually
+        # Check for a currently running instance of the agent
+        RUNNING_AGENT="$(ps -ax | grep 'ssh-agent -s' | grep -v grep | wc -l | tr -d '[:space:]')"
+        if [ "$RUNNING_AGENT" = "0" ]; then
           if [ ! -d ~/.ssh ] ; then
-          mkdir -p ~/.ssh
-        fi
-        # Launch a new instance of the agent
+            mkdir -p ~/.ssh
+          fi
+          # Launch a new instance of the agent
           ssh-agent -s &> ~/.ssh/ssh-agent
-       fi
-       eval $(cat ~/.ssh/ssh-agent)
+        fi
+        eval $(cat ~/.ssh/ssh-agent)
       fi
-  fi
+    fi
   fi
 
   local key_manager=ssh-add


### PR DESCRIPTION
# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

<!--- Provide a general summary of your changes in the Title above -->

## Description

The sock file path was only valid on macOS. Add `uname -s` checks for `Darwin` and `Linux` so we can set appropriate sock file path.

Closes #265

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [x] Bug fix
- [ ] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the readme if this PR changes/updates quickstart functionality.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
