### PR TITLE
Add an option to not load `ssh` keys during session startup

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,8 @@
       - [zqs disable-ssh-askpass-require](#zqs-disable-ssh-askpass-require)
       - [zqs-disable-ssh-key-listing](#zqs-disable-ssh-key-listing)
       - [zqs-enable-ssh-key-listing](#zqs-enable-ssh-key-listing)
+      - [zqs-disable-ssh-key-loading](#zqs-disable-ssh-key-loading)
+      - [zqs-enable-ssh-key-loading](#zqs-enable-ssh-key-loading)
       - [zqs-disable-zmv-autoloading](#zqs-disable-zmv-autoloading)
       - [zqs-enable-zmv-autoloading](#zqs-enable-zmv-autoloading)
       - [zqs selfupdate](#zqs-selfupdate)
@@ -274,6 +276,14 @@ Don't print the loaded `ssh` keys when creating a new session.
 ##### zqs-enable-ssh-key-listing
 
 Print the loaded `ssh` keys when creating a new session. This is the default behavior.
+
+##### zqs-disable-ssh-key-loading
+
+Don't load `ssh` keys when creating a new session. Useful if you're storing your private keys in a [yubikey](https://www.yubico.com/).
+
+##### zqs-enable-ssh-key-loading
+
+Load missing `ssh` private keys when creating a new session. This is the default behavior.
 
 ##### zqs-disable-zmv-autoloading
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -376,7 +376,10 @@ if [[ -z "$SSH_CLIENT" ]] || can_haz keychain; then
   if [[ "$(_zqs-get-setting ssh-askpass-require)" == 'true' ]]; then
     zsh-quickstart-set-ssh-askpass-require
   fi
-  load-our-ssh-keys
+  load_ssh_keys="$(_zqs-get-setting load-ssh-keys true)"
+  if [[ "$load_ssh_keys" != "false" ]]; then
+    load-our-ssh-keys
+  fi
 fi
 
 # Load helper functions before we load zgenom setup
@@ -750,17 +753,19 @@ function zqs-help() {
   echo ""
   echo "Quickstart settings commands:"
   echo "zqs disable-bindkey-handling - Set the quickstart to not touch any bindkey settings. Useful if you're using another plugin to handle it."
-  echo "zqs enable-bindkey-handling - Set the quickstart to configure your bindkey settings. Default behavior."
+  echo "zqs enable-bindkey-handling - Set the quickstart to configure your bindkey settings. This is the default behavior."
   echo "zqs enable-control-c-decorator - Creates a TRAPINT function to display '^C' when you type control-c instead of being silent. Default behavior."
   echo "zqs disable-control-c-decorator - No longer creates a TRAPINT function to display '^C' when you type control-c."
   echo "zqs disable-omz-plugins - Set the quickstart to not load oh-my-zsh plugins if you're using the standard plugin list"
   echo "zqs enable-omz-plugins - Set the quickstart to load oh-my-zsh plugins if you're using the standard plugin list"
   echo "zqs enable-ssh-askpass-require - Set the quickstart to prompt for your ssh passphrase on the command line."
-  echo "zqs disable-ssh-askpass-require - Set the quickstart to prompt for your ssh passphrase via a gui program. Default behavior"
+  echo "zqs disable-ssh-askpass-require - Set the quickstart to prompt for your ssh passphrase via a gui program. This is the default behavior"
   echo "zqs disable-ssh-key-listing - Set the quickstart to not display all the loaded ssh keys"
-  echo "zqs enable-ssh-key-listing - Set the quickstart to display all the loaded ssh keys. Default behavior."
+  echo "zqs enable-ssh-key-listing - Set the quickstart to display all the loaded ssh keys. This is the default behavior."
+  echo "zqs disable-ssh-key-loading - Set the quickstart to not load your ssh keys. Useful if you're storing them in a yubikey."
+  echo "zqs enable-ssh-key-loading - Set the quickstart to load your ssh keys if they aren't already in an ssh agent. This is the default behavior."
   echo "zqs disable-zmv-autoloading - Set the quickstart to not run 'autoload -U zmv'. Useful if you're using another plugin to handle it."
-  echo "zqs enable-zmv-autoloading - Set the quickstart to run 'autoload -U zmv'. Default behavior."
+  echo "zqs enable-zmv-autoloading - Set the quickstart to run 'autoload -U zmv'. This is the default behavior."
   echo "zqs delete-setting SETTINGNAME - Remove a zqs setting file"
   echo "zqs get-setting SETTINGNAME [optional default value] - load a zqs setting"
   echo "zqs set-setting SETTINGNAME value - Set an arbitrary zqs setting"
@@ -807,6 +812,12 @@ function zqs() {
       ;;
     'disable-ssh-key-listing')
       _zqs-set-setting list-ssh-keys false
+      ;;
+    'disable-ssh-key-loading')
+      _zqs-set-setting load-ssh-keys false
+      ;;
+    'enable-ssh-key-loading')
+      _zqs-set-setting load-ssh-keys true
       ;;
     'selfupdate')
       _update-zsh-quickstart


### PR DESCRIPTION


# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Make it easy to make the quickstart not attempt to load `ssh` keys. This makes it easier for someone to store their `ssh` private keys in a yubikey.

Closes #267

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [ ] Bug fix
- [x] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the readme if this PR changes/updates quickstart functionality.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
