### PR TITLE
Added aliases for the new "official" fork eza instead of exa

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -568,23 +568,28 @@ if (( $+commands[gls] )); then
   alias la='gls -A --color'
 fi
 
-# When present, use exa instead of ls
-if can_haz exa; then
-  if [[ -z "$EXA_TREE_IGNORE" ]]; then
-    EXA_TREE_IGNORE=".cache|cache|node_modules|vendor|.git"
-  fi
+# When present, use exa or eza (newest) instead of ls
+if can_haz eza; then
+  ls_analog='eza'
+elif can_haz exa; then
+  ls_analog='exa'
+fi
 
-  if [[ "$(exa --help | grep -c git)" == 0 ]]; then
+if [ -v ls_analog ]; then
+  if [[ "$($ls_analog --help | grep -c git)" == 0 ]]; then
     # Not every linux exa build has git support compiled in
-    alias l='exa -al --icons --time-style=long-iso --group-directories-first --color-scale'
+    alias l="$ls_analog -al --icons --time-style=long-iso --group-directories-first --color-scale"
   else
-    alias l='exa -al --icons --git --time-style=long-iso --group-directories-first --color-scale'
+    alias l="$ls_analog -al --icons --git --time-style=long-iso --group-directories-first --color-scale"
   fi
-  alias ls='exa --group-directories-first'
+  alias ls="$ls_analog --group-directories-first"
 
   # Don't step on system-installed tree command
   if ! can_haz tree; then
-    alias tree='exa --tree'
+    if [[ -z "$TREE_IGNORE" ]]; then
+        TREE_IGNORE=".cache|cache|node_modules|vendor|.git"
+    fi
+    alias tree="$ls_analog --tree --ignore-glob='$TREE_IGNORE'"
   fi
 fi
 


### PR DESCRIPTION
# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

Added eza check and alias generation taking into account the installed application - exa or eza

## Description

In the official Exa repository it says to use the new Eza fork now. In this PR I check if `eza` is available and if it is not, I check if `exa` is installed. Then the correct aliases are formed with the correct application.

I also noticed that the environment variable `EXA_TREE_IGNORE` is not used in either `exa` or `eza`. I kept the environment variable, but changed its name to a more neutral one and passed its value explicitly to the `tree` alias call.

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [ ] Bug fix
- [x] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the readme if this PR changes/updates quickstart functionality.
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have added a credit line to README.md for the script
- [x] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
