### PR TITLE
Add os-specific fragment file directories

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,6 +50,7 @@
     - [Customizing with ~/.zshrc.d](#customizing-with-zshrcd)
   - [I like a plugin, but some of the aliases and functions it installs overwrite other commands or aliases I use](#i-like-a-plugin-but-some-of-the-aliases-and-functions-it-installs-overwrite-other-commands-or-aliases-i-use)
   - [ZSH options](#zsh-options)
+    - [Fragment file directories](#fragment-file-directories)
   - [Self-update Settings](#self-update-settings)
   - [Customizing the plugin list](#customizing-the-plugin-list)
     - [Using fragment files](#using-fragment-files)
@@ -341,9 +342,15 @@ Once you've cleared all the unwanted aliases and functions, you can add new ones
 
 The quickstart kit does an opinionated (i.e., my way) setup of ZSH options and adds some functions and aliases I like on my systems.
 
-However, `~/.zshrc.d` is processed *after* the quickstart sets its aliases, functions, and ZSH options, so if you don't care for something as set up in the quickstart, you can override the offending item in a shell fragment file there.
+#### Fragment file directories
 
-The kit also looks for files in `~/.zshrc.pre-plugins.d`, and you can use snippet files in there to set environment variables that alter the startup behavior of plugins.
+You can customize the quickstart by adding files to its `zshrc.d` directories.
+
+After the quickstart sets up its aliases, functions, plugins and ZSH options, it will source every fragment file in `~/.zshrc.d`.
+
+If you want to set variables _before_ the quickstart starts setup to alter behavior, stick your fragment files in `~/.zshrc.pre-plugins.d`.
+
+To make it easier to have macOS or Linux-specific settings tweaks, the quickstart also supports os-specific pre & post `.zshrc.d` directories. If you want a file to only be sourced on a single os, the quickstart also checks for `.zshrc.pre-plugins.$(uname).d` and `~/.zshrc.$(uname).d` during loading.
 
 ### Self-update Settings
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -393,6 +393,10 @@ fi
 mkdir -p ~/.zshrc.pre-plugins.d
 load-shell-fragments ~/.zshrc.pre-plugins.d
 
+if [[ -d "$HOME/.zshrc.pre-plugins.$(uname).d" ]]; then
+  load-shell-fragments "$HOME/.zshrc.pre-plugins.$(uname).d"
+fi
+
 # macOS doesn't have a python by default. This makes the omz python and
 # zsh-completion-generator plugins sad, so if there isn't a python, alias
 # it to python3
@@ -617,6 +621,10 @@ fi
 # quickstart's defaults by loading all files from the ~/.zshrc.d directory
 mkdir -p ~/.zshrc.d
 load-shell-fragments ~/.zshrc.d
+
+if [[ -d "$HOME/.zshrc.$(uname).d" ]]; then
+  load-shell-fragments "$HOME/.zshrc.$(uname).d"
+fi
 
 # If GOPATH is defined, add it to $PATH
 if [[ -n "$GOPATH" ]]; then


### PR DESCRIPTION


# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Make it easy to have fragment files that are only sourced on a specific OS.

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [ ] Bug fix
- [x] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the readme if this PR changes/updates quickstart functionality.
- [ ] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
