### PR TITLE
Update 'fzf' installation instructions in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -131,7 +131,10 @@ To enable the enhanced history search, you'll need to install [fzf](https://gith
 6. Install some Powerline-compatible or NerdFont fonts from one of the links in the Fonts section above.
     1. In iTerm 2, go to Preferences->Profile in your iTerm 2 preferences, then select one of the Powerline-compatible fonts you just installed.
     2. **Make sure you also specify a Powerline-compatible font for non-ASCII in your iTerm 2 preferences or the prompt separators and branch glyphs will show up garbled**.
-7. Install `fzf` with `brew install fzf`
+7. Install `fzf`
+    1. Install `fzf` with `brew install fzf`
+    2. Run the `zsh "$(brew --prefix fzf)/install"` command to configure `fzf`
+    3. Press `Enter` (`y` default) for all questions except `Do you want to update your shell configuration files? ([y]/n)`. For this question, select `n` and press `Enter`.
 
 </details>
 

--- a/Readme.md
+++ b/Readme.md
@@ -133,7 +133,7 @@ To enable the enhanced history search, you'll need to install [fzf](https://gith
     2. **Make sure you also specify a Powerline-compatible font for non-ASCII in your iTerm 2 preferences or the prompt separators and branch glyphs will show up garbled**.
 7. Install `fzf`
     1. Install `fzf` with `brew install fzf`
-    2. Run the `zsh "$(brew --prefix fzf)/install"` command to configure `fzf`
+    2. Run the `sh "$(brew --prefix fzf)/install"` command to configure `fzf`
     3. Press `Enter` (`y` default) for all questions except `Do you want to update your shell configuration files? ([y]/n)`. For this question, select `n` and press `Enter`.
 
 </details>


### PR DESCRIPTION
# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The commit adds more detailed steps for the installation and configuration of 'fzf'. It specifies the exact commands to be run and provides guidance on the prompts users might encounter, improving clarity for users unfamiliar with the process. Resolves #286 

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [x] Text cleanups/updates
- [ ] Test updates
- [ ] Bug fix
- [ ] New feature
- [ ] Plugin list change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the readme if this PR changes/updates quickstart functionality.
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have added a credit line to README.md for the script
- [x] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
