### PR TITLE
Make zsh-quickstart-kit ZDOTDIR-aware and nounset-resilient

### DIFF
--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -8,229 +8,229 @@
 # BSD licensed, see LICENSE.txt
 
 # Clone zgenom if you haven't already
-if [[ -z "$ZGENOM_PARENT_DIR" ]]; then
-  ZGENOM_PARENT_DIR=$HOME
-  ZGENOM_SOURCE_FILE=$ZGENOM_PARENT_DIR/.zqs-zgenom/zgenom.zsh
+if [[ -z ${ZGENOM_PARENT_DIR-} ]]; then
+    ZGENOM_PARENT_DIR=${ZDOTDIR:-$HOME}
+    ZGENOM_SOURCE_FILE="$ZGENOM_PARENT_DIR/.zqs-zgenom/zgenom.zsh"
 
-  # Set ZGENOM_SOURCE_FILE to the old directory if it already exists
-  if [[ -f "$ZGENOM_PARENT_DIR/zgenom/zgenom.zsh" ]] ; then
-    ZGENOM_SOURCE_FILE=$ZGENOM_PARENT_DIR/zgenom/zgenom.zsh
-  fi
+    # Set ZGENOM_SOURCE_FILE to the old directory if it already exists
+    if [[ -f "$ZGENOM_PARENT_DIR/zgenom/zgenom.zsh" ]] ; then
+        ZGENOM_SOURCE_FILE="$ZGENOM_PARENT_DIR/zgenom/zgenom.zsh"
+    fi
 fi
 
 # zgenom stores the clones plugins & themes in $ZGEN_DIR when it
 # is set. Otherwise it stuffs everything in the source tree, which
 # is unclean.
-ZGEN_DIR=${ZGEN_DIR:-$HOME/.zgenom}
+ZGEN_DIR=${ZGEN_DIR:-${ZDOTDIR:-$HOME}/.zgenom}
 
 if [[ ! -f "$ZGENOM_SOURCE_FILE" ]] ; then
-  if [[ ! -d "$ZGENOM_PARENT_DIR" ]]; then
-    mkdir -p "$ZGENOM_PARENT_DIR"
-  fi
-  pushd $ZGENOM_PARENT_DIR
-  git clone https://github.com/jandamm/zgenom.git .zqs-zgenom
-  popd
+    if [[ ! -d "$ZGENOM_PARENT_DIR" ]]; then
+        mkdir -p "$ZGENOM_PARENT_DIR"
+    fi
+    pushd $ZGENOM_PARENT_DIR
+    git clone https://github.com/jandamm/zgenom.git .zqs-zgenom
+    popd
 fi
 
 if [[ ! -f "$ZGENOM_SOURCE_FILE" ]] ; then
-  echo "Can't find zgenom.zsh"
+    echo "Can't find zgenom.zsh"
 else
-  # echo "Loading zgenom"
-  source "$ZGENOM_SOURCE_FILE"
+    # echo "Loading zgenom"
+    source "$ZGENOM_SOURCE_FILE"
 fi
 
 unset ZGENOM_PARENT_DIR ZGENOM_SOURCE_FILE
 
 warn-about-prompt-change() {
-  if [[ ! -f ~/.zsh-quickstart-kit-prompt-switch-warning ]]; then
-    echo
-    echo "The default ZSH prompt in the quickstart kit has changed from"
-    echo "bullet-train to powerlevel10k."
-    echo
-    echo "If you want to use the old prompt, run zsh-quickstart-select-bullet-train"
-    echo
-    echo "Run zsh-quickstart-select-powerlevel10k to switch to the new prompt"
-    echo
-    echo "If you do nothing, you will be switched to powerlevel10k"
-    echo
-    touch ~/.zsh-quickstart-kit-prompt-switch-warning
-  fi
+    if [[ ! -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-kit-prompt-switch-warning ]]; then
+        echo
+        echo "The default ZSH prompt in the quickstart kit has changed from"
+        echo "bullet-train to powerlevel10k."
+        echo
+        echo "If you want to use the old prompt, run zsh-quickstart-select-bullet-train"
+        echo
+        echo "Run zsh-quickstart-select-powerlevel10k to switch to the new prompt"
+        echo
+        echo "If you do nothing, you will be switched to powerlevel10k"
+        echo
+        touch ${ZDOTDIR:-$HOME}/.zsh-quickstart-kit-prompt-switch-warning
+    fi
 }
 
 load-starter-plugin-list() {
-  echo "Creating a zgenom save"
-  ZGEN_LOADED=()
-  ZGEN_COMPLETIONS=()
+    echo "Creating a zgenom save"
+    ZGEN_LOADED=()
+    ZGEN_COMPLETIONS=()
 
-  if [[ ! -f ~/.zsh-quickstart-no-omz ]] || [[ $(_zqs-get-setting load-omz-plugins true) == 'true' ]]; then
-    zgenom oh-my-zsh
-  fi
-
-  # If you want to customize your plugin list, create a file named
-  # .zsh-quickstart-local-plugins-example in your home directory. That
-  # file will be sourced during startup *instead* of running this
-  # load-starter-plugin-list function, so make sure to include everything
-  # from this function that you want to keep.
-  #
-  # To make customizing easier, there's a .zsh-quickstart-local-plugins-example
-  # file at the top level of the zsh-quickstart-kit repository that you can
-  # copy as a starting point. This keeps you from having to maintain a fork of
-  # the quickstart kit.
-
-  # If zsh-syntax-highlighting is bundled after zsh-history-substring-search,
-  # they break, so get the order right.
-  zgenom load zdharma-continuum/fast-syntax-highlighting
-  zgenom load zsh-users/zsh-history-substring-search
-
-  # Set keystrokes for substring searching
-  zmodload zsh/terminfo
-  bindkey "$terminfo[kcuu1]" history-substring-search-up
-  bindkey "$terminfo[kcud1]" history-substring-search-down
-
-  # Tab complete rakefile targets.
-  zgenom load unixorn/rake-completion.zshplugin
-
-  # Automatically run zgenom update and zgenom selfupdate every 7 days.
-  zgenom load unixorn/autoupdate-zgenom
-
-  # Add my collection of miscellaneous utility functions.
-  zgenom load unixorn/jpb.zshplugin
-
-  # Colorize the things if you have grc installed. Well, some of the
-  # things, anyway.
-  zgenom load unixorn/warhol.plugin.zsh
-
-  # macOS helpers. This plugin is smart enough to detect when it isn't running
-  # on macOS and not load itself, so you can safely share the same plugin list
-  # across macOS and Linux/BSD.
-  zgenom load unixorn/tumult.plugin.zsh
-
-  # Deal with Apple's squirrelly DNS
-  zgenom load eventi/noreallyjustfuckingstopalready
-
-  # Warn you when you run a command that you've set an alias for without
-  # using the alias.
-  zgenom load djui/alias-tips
-
-  # Add my collection of git helper scripts.
-  zgenom load unixorn/git-extra-commands
-
-  # Add diff-so-fancy so git can use it
-  if [[ "$(_zqs-get-setting diff-so-fancy true)" == 'true' ]]; then
-    zgenom load so-fancy/diff-so-fancy
-  fi
-
-  # Supercharge your history search with fzf
-  zgenom load unixorn/fzf-zsh-plugin
-
-  # Add my bitbucket git helpers plugin.
-  zgenom load unixorn/bitbucket-git-helpers.plugin.zsh
-
-  # A collection of scripts that might be useful to sysadmins.
-  zgenom load skx/sysadmin-util
-
-  # Adds aliases to open your current repo & branch on github.
-  zgenom load peterhurford/git-it-on.zsh
-
-  # Tom Limoncelli's tooling for storing private information (keys, etc)
-  # in a repository securely by encrypting them with gnupg.
-  zgenom load StackExchange/blackbox
-
-  if [[ -f ~/.zqs-add-plugins ]]; then
-    source ~/.zqs-add-plugins
-  fi
-
-  if [[ -d ~/.zshrc.add-plugins.d ]]; then
-    load-shell-fragments ~/.zshrc.add-plugins.d
-  fi
-
-  if [[ ! -f ~/.zsh-quickstart-no-omz ]] || [[ $(_zqs-get-setting load-omz-plugins false) == 'true' ]]; then
-    # Load some oh-my-zsh plugins
-    zgenom oh-my-zsh plugins/pip
-    zgenom oh-my-zsh plugins/sudo
-    zgenom oh-my-zsh plugins/aws
-    zgenom oh-my-zsh plugins/chruby
-    zgenom oh-my-zsh plugins/colored-man-pages
-    zgenom oh-my-zsh plugins/git
-    zgenom oh-my-zsh plugins/github
-    zgenom oh-my-zsh plugins/python
-    zgenom oh-my-zsh plugins/rsync
-    zgenom oh-my-zsh plugins/screen
-    zgenom oh-my-zsh plugins/vagrant
-
-    if (( $+commands[brew] )); then
-      zgenom oh-my-zsh plugins/brew
+    if [[ ! -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-no-omz ]] || [[ $(_zqs-get-setting load-omz-plugins true) == 'true' ]]; then
+        zgenom oh-my-zsh
     fi
 
-    if [ $(uname -a | grep -ci Darwin) = 1 ]; then
-      # Load macOS-specific plugins
-      zgenom oh-my-zsh plugins/macos
+    # If you want to customize your plugin list, create a file named
+    # .zsh-quickstart-local-plugins-example in your home directory. That
+    # file will be sourced during startup *instead* of running this
+    # load-starter-plugin-list function, so make sure to include everything
+    # from this function that you want to keep.
+    #
+    # To make customizing easier, there's a .zsh-quickstart-local-plugins-example
+    # file at the top level of the zsh-quickstart-kit repository that you can
+    # copy as a starting point. This keeps you from having to maintain a fork of
+    # the quickstart kit.
+
+    # If zsh-syntax-highlighting is bundled after zsh-history-substring-search,
+    # they break, so get the order right.
+    zgenom load zdharma-continuum/fast-syntax-highlighting
+    zgenom load zsh-users/zsh-history-substring-search
+
+    # Set keystrokes for substring searching
+    zmodload zsh/terminfo
+    bindkey "$terminfo[kcuu1]" history-substring-search-up
+    bindkey "$terminfo[kcud1]" history-substring-search-down
+
+    # Tab complete rakefile targets.
+    zgenom load unixorn/rake-completion.zshplugin
+
+    # Automatically run zgenom update and zgenom selfupdate every 7 days.
+    zgenom load unixorn/autoupdate-zgenom
+
+    # Add my collection of miscellaneous utility functions.
+    zgenom load unixorn/jpb.zshplugin
+
+    # Colorize the things if you have grc installed. Well, some of the
+    # things, anyway.
+    zgenom load unixorn/warhol.plugin.zsh
+
+    # macOS helpers. This plugin is smart enough to detect when it isn't running
+    # on macOS and not load itself, so you can safely share the same plugin list
+    # across macOS and Linux/BSD.
+    zgenom load unixorn/tumult.plugin.zsh
+
+    # Deal with Apple's squirrelly DNS
+    zgenom load eventi/noreallyjustfuckingstopalready
+
+    # Warn you when you run a command that you've set an alias for without
+    # using the alias.
+    zgenom load djui/alias-tips
+
+    # Add my collection of git helper scripts.
+    zgenom load unixorn/git-extra-commands
+
+    # Add diff-so-fancy so git can use it
+    if [[ "$(_zqs-get-setting diff-so-fancy true)" == 'true' ]]; then
+        zgenom load so-fancy/diff-so-fancy
     fi
-  fi
 
-  # A set of shell functions to make it easy to install small apps and
-  # utilities distributed with pip.
-  zgenom load sharat87/pip-app
+    # Supercharge your history search with fzf
+    zgenom load unixorn/fzf-zsh-plugin
 
-  zgenom load chrissicool/zsh-256color
+    # Add my bitbucket git helpers plugin.
+    zgenom load unixorn/bitbucket-git-helpers.plugin.zsh
 
-  # Load more completion files for zsh from the zsh-lovers github repo.
-  zgenom load zsh-users/zsh-completions src
+    # A collection of scripts that might be useful to sysadmins.
+    zgenom load skx/sysadmin-util
 
-  # Docker completion
-  zgenom load srijanshetty/docker-zsh
+    # Adds aliases to open your current repo & branch on github.
+    zgenom load peterhurford/git-it-on.zsh
 
-  # Load tab completions for 1Password's op command line tool if it's installed
-  zgenom load unixorn/1password-op.plugin.zsh
+    # Tom Limoncelli's tooling for storing private information (keys, etc)
+    # in a repository securely by encrypting them with gnupg.
+    zgenom load StackExchange/blackbox
 
-  # Load me last
-  GENCOMPL_FPATH=$HOME/.zsh/complete
+    if [[ -f ${ZDOTDIR:-$HOME}/.zqs-add-plugins ]]; then
+        source ${ZDOTDIR:-$HOME}/.zqs-add-plugins
+    fi
 
-  # Very cool plugin that generates zsh completion functions for commands
-  # if they have getopt-style help text. It doesn't generate them on the fly,
-  # you'll have to explicitly generate a completion, but it's still quite cool.
-  zgenom load RobSis/zsh-completion-generator
+    if [[ -d ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d ]]; then
+        load-shell-fragments ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d
+    fi
 
-  # Add Fish-like autosuggestions to your ZSH.
-  zgenom load zsh-users/zsh-autosuggestions
+    if [[ ! -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-no-omz ]] || [[ $(_zqs-get-setting load-omz-plugins false) == 'true' ]]; then
+        # Load some oh-my-zsh plugins
+        zgenom oh-my-zsh plugins/pip
+        zgenom oh-my-zsh plugins/sudo
+        zgenom oh-my-zsh plugins/aws
+        zgenom oh-my-zsh plugins/chruby
+        zgenom oh-my-zsh plugins/colored-man-pages
+        zgenom oh-my-zsh plugins/git
+        zgenom oh-my-zsh plugins/github
+        zgenom oh-my-zsh plugins/python
+        zgenom oh-my-zsh plugins/rsync
+        zgenom oh-my-zsh plugins/screen
+        zgenom oh-my-zsh plugins/vagrant
 
-  # k is a zsh script / plugin to make directory listings more readable,
-  # adding a bit of color and some git status information on files and
-  # directories.
-  zgenom load supercrabtree/k
+        if (( $+commands[brew] )); then
+            zgenom oh-my-zsh plugins/brew
+        fi
 
-  # Be compatible with the old settings files for now
-  if [[ -f ~/.zsh-quickstart-use-bullet-train ]] || [[ $(_zqs-get-setting bullet-train false) == 'true' ]]; then
-    # Bullet train prompt setup.
-    zgenom load https://github.com/caiogondim/bullet-train.zsh
-  else
-    # p10k is faster and what I'm using now, so it is the new default
-    zgenom load romkatv/powerlevel10k powerlevel10k
-    warn-about-prompt-change
-  fi
+        if [ $(uname -a | grep -ci Darwin) = 1 ]; then
+            # Load macOS-specific plugins
+            zgenom oh-my-zsh plugins/macos
+        fi
+    fi
 
-  # Save it all to init script.
-  zgenom save
+    # A set of shell functions to make it easy to install small apps and
+    # utilities distributed with pip.
+    zgenom load sharat87/pip-app
+
+    zgenom load chrissicool/zsh-256color
+
+    # Load more completion files for zsh from the zsh-lovers github repo.
+    zgenom load zsh-users/zsh-completions src
+
+    # Docker completion
+    zgenom load srijanshetty/docker-zsh
+
+    # Load tab completions for 1Password's op command line tool if it's installed
+    zgenom load unixorn/1password-op.plugin.zsh
+
+    # Load me last
+    GENCOMPL_FPATH=${ZDOTDIR:-$HOME}/.zsh/complete
+
+    # Very cool plugin that generates zsh completion functions for commands
+    # if they have getopt-style help text. It doesn't generate them on the fly,
+    # you'll have to explicitly generate a completion, but it's still quite cool.
+    zgenom load RobSis/zsh-completion-generator
+
+    # Add Fish-like autosuggestions to your ZSH.
+    zgenom load zsh-users/zsh-autosuggestions
+
+    # k is a zsh script / plugin to make directory listings more readable,
+    # adding a bit of color and some git status information on files and
+    # directories.
+    zgenom load supercrabtree/k
+
+    # Be compatible with the old settings files for now
+    if [[ -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-use-bullet-train ]] || [[ $(_zqs-get-setting bullet-train false) == 'true' ]]; then
+        # Bullet train prompt setup.
+        zgenom load https://github.com/caiogondim/bullet-train.zsh
+    else
+        # p10k is faster and what I'm using now, so it is the new default
+        zgenom load romkatv/powerlevel10k powerlevel10k
+        warn-about-prompt-change
+    fi
+
+    # Save it all to init script.
+    zgenom save
 }
 
 setup-zgen-repos() {
-  ZQS_override_plugin_list=''
-  # Check the old name for backward compatibility
-  if [[ -r $HOME/.zgen-local-plugins ]]; then
-    ZQS_override_plugin_list="$HOME/.zgen-local-plugins"
-  fi
-  # If they have both, the new name takes precedence
-  if [[ -r $HOME/.zsh-quickstart-local-plugins ]]; then
-    ZQS_override_plugin_list="$HOME/.zsh-quickstart-local-plugins"
-  fi
+    ZQS_override_plugin_list=''
+    # Check the old name for backward compatibility
+    if [[ -r ${ZDOTDIR:-$HOME}/.zgen-local-plugins ]]; then
+        ZQS_override_plugin_list="${ZDOTDIR:-$HOME}/.zgen-local-plugins"
+    fi
+    # If they have both, the new name takes precedence
+    if [[ -r ${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins ]]; then
+        ZQS_override_plugin_list="${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins"
+    fi
 
-  if [[ -r "$ZQS_override_plugin_list" ]]; then
-    echo "Loading local plugin list from $ZQS_override_plugin_list"
-    source "$ZQS_override_plugin_list"
-    unset ZQS_override_plugin_list
-  else
-    load-starter-plugin-list
-  fi
+    if [[ -r "$ZQS_override_plugin_list" ]]; then
+        echo "Loading local plugin list from $ZQS_override_plugin_list"
+        source "$ZQS_override_plugin_list"
+        unset ZQS_override_plugin_list
+    else
+        load-starter-plugin-list
+    fi
 }
 
 # This comes from https://stackoverflow.com/questions/17878684/best-way-to-get-file-modified-time-in-seconds
@@ -239,24 +239,24 @@ setup-zgen-repos() {
 # Naturally BSD/macOS and Linux can't share the same options to stat.
 if [[ $(uname | grep -ci -e Darwin -e BSD) = 1 ]]; then
 
-  # macOS version.
-  get_file_modification_time() {
-    modified_time=$(stat -f %m "$1" 2> /dev/null) || modified_time=0
-    echo "${modified_time}"
-  }
+    # macOS version.
+    get_file_modification_time() {
+        modified_time=$(stat -f %m "$1" 2> /dev/null) || modified_time=0
+        echo "${modified_time}"
+    }
 
 elif [[ $(uname | grep -ci Linux) = 1 ]]; then
 
-  # Linux version.
-  get_file_modification_time() {
-    modified_time=$(stat -c %Y "$1" 2> /dev/null) || modified_time=0
-    echo "${modified_time}"
-  }
+    # Linux version.
+    get_file_modification_time() {
+        modified_time=$(stat -c %Y "$1" 2> /dev/null) || modified_time=0
+        echo "${modified_time}"
+    }
 fi
 
 # check if there's an init.zsh file for zgen and generate one if not.
 if ! zgenom saved; then
-  setup-zgen-repos
+    setup-zgen-repos
 fi
 
 # Our installation instructions get the user to make a symlink
@@ -266,11 +266,11 @@ fi
 # Unfortunately, stat will return the modification time of the
 # symlink instead of the target file, so construct a full path to hand off
 # to stat so it returns the modification time of the actual .zgen-setup file.
-if [[ -f ~/.zgen-setup ]]; then
-  REAL_ZGEN_SETUP=~/.zgen-setup
+if [[ -f ${ZDOTDIR:-$HOME}/.zgen-setup ]]; then
+    REAL_ZGEN_SETUP=${ZDOTDIR:-$HOME}/.zgen-setup
 fi
-if [[ -L ~/.zgen-setup ]]; then
-  REAL_ZGEN_SETUP="$(readlink ~/.zgen-setup)"
+if [[ -L ${ZDOTDIR:-$HOME}/.zgen-setup ]]; then
+    REAL_ZGEN_SETUP="$(readlink ${ZDOTDIR:-$HOME}/.zgen-setup)"
 fi
 
 # If you don't want my standard starter set of plugins, create a file named
@@ -282,48 +282,48 @@ fi
 #
 # Use readlink in case the user is symlinking from another repo checkout, so
 # they can use a personal dotfiles repository cleanly.
-if [[ -f ~/.zgen-local-plugins ]]; then
-  REAL_ZGEN_SETUP=~/.zgen-local-plugins
+if [[ -f ${ZDOTDIR:-$HOME}/.zgen-local-plugins ]]; then
+    REAL_ZGEN_SETUP=${ZDOTDIR:-$HOME}/.zgen-local-plugins
 fi
-if [[ -L ~/.zgen-local-plugins ]]; then
-  REAL_ZGEN_SETUP="${HOME}/$(readlink ~/.zgen-local-plugins)"
+if [[ -L ${ZDOTDIR:-$HOME}/.zgen-local-plugins ]]; then
+    REAL_ZGEN_SETUP="${ZDOTDIR:-$HOME}/$(readlink ${ZDOTDIR:-$HOME}/.zgen-local-plugins)"
 fi
 # Old file still works for backward compatibility, but we want the new file
 # to take precedence when both exist.
-if [[ -f ~/.zsh-quickstart-local-plugins ]]; then
-  REAL_ZGEN_SETUP=~/.zsh-quickstart-local-plugins
+if [[ -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins ]]; then
+    REAL_ZGEN_SETUP=${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins
 fi
-if [[ -L ~/.zsh-quickstart-local-plugins ]]; then
-  REAL_ZGEN_SETUP="${HOME}/$(readlink ~/.zsh-quickstart-local-plugins)"
+if [[ -L ${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins ]]; then
+    REAL_ZGEN_SETUP="${ZDOTDIR:-$HOME}/$(readlink ${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins)"
 fi
 
 # If .zgen-setup is newer than init.zsh, regenerate init.zsh
-if [ $(get_file_modification_time ${REAL_ZGEN_SETUP}) -gt $(get_file_modification_time ~/.zgenom/init.zsh) ]; then
-  echo "$(basename ${REAL_ZGEN_SETUP}) ($REAL_ZGEN_SETUP) updated; creating a new init.zsh from plugin list in ${REAL_ZGEN_SETUP}"
-  setup-zgen-repos
-elif [ -d ~/.zshrc.add-plugins.d ]; then
-  init_timestamp=$(get_file_modification_time ~/.zgenom/init.zsh)
-  plugins_dir_timestamp=$(get_file_modification_time ~/.zshrc.add-plugins.d)
-  if [ "$plugins_dir_timestamp" -gt "$init_timestamp" ]; then
-      need_update="true"
-  fi
-
-  if [[ -n "$("ls" -A ~/.zshrc.add-plugins.d)" ]] && [[ -z $need_update ]]; then
-    for file in ~/.zshrc.add-plugins.d/*; do
-      if [[ $(get_file_modification_time "${file}") -gt ${init_timestamp} ]]; then
-        need_update="true"
-        break
-      fi
-    done
-  fi
-
-  if [[ -n $need_update ]]; then
-    echo "Some files in ~/.zshrc.add-plugins.d updated; creating a new init.zsh from plugin list in ${REAL_ZGEN_SETUP} and plugins dir"
+if [ $(get_file_modification_time ${REAL_ZGEN_SETUP}) -gt $(get_file_modification_time ${ZDOTDIR:-$HOME}/.zgenom/init.zsh) ]; then
+    echo "$(basename ${REAL_ZGEN_SETUP}) ($REAL_ZGEN_SETUP) updated; creating a new init.zsh from plugin list in ${REAL_ZGEN_SETUP}"
     setup-zgen-repos
-  fi
-  unset init_timestamp
-  unset plugins_dir_timestamp
-  unset need_update
+elif [ -d ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d ]; then
+    init_timestamp=$(get_file_modification_time ${ZDOTDIR:-$HOME}/.zgenom/init.zsh)
+    plugins_dir_timestamp=$(get_file_modification_time ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d)
+    if [ "$plugins_dir_timestamp" -gt "$init_timestamp" ]; then
+        need_update="true"
+    fi
+
+    if [[ -n "$("ls" -A ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d)" ]] && [[ -z ${need_update-} ]]; then
+        for file in ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d/*; do
+            if [[ $(get_file_modification_time "${file}") -gt ${init_timestamp} ]]; then
+                need_update="true"
+                break
+            fi
+        done
+    fi
+
+    if [[ -n ${need_update-} ]]; then
+        echo "Some files in ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d updated; creating a new init.zsh from plugin list in ${REAL_ZGEN_SETUP} and plugins dir"
+        setup-zgen-repos
+    fi
+    unset init_timestamp
+    unset plugins_dir_timestamp
+    unset need_update
 fi
 
 unset REAL_ZGEN_SETUP

--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -9,13 +9,13 @@
 
 # Clone zgenom if you haven't already
 if [[ -z ${ZGENOM_PARENT_DIR-} ]]; then
-    ZGENOM_PARENT_DIR=${ZDOTDIR:-$HOME}
-    ZGENOM_SOURCE_FILE="$ZGENOM_PARENT_DIR/.zqs-zgenom/zgenom.zsh"
+  ZGENOM_PARENT_DIR=${ZDOTDIR:-$HOME}
+  ZGENOM_SOURCE_FILE="$ZGENOM_PARENT_DIR/.zqs-zgenom/zgenom.zsh"
 
-    # Set ZGENOM_SOURCE_FILE to the old directory if it already exists
-    if [[ -f "$ZGENOM_PARENT_DIR/zgenom/zgenom.zsh" ]] ; then
-        ZGENOM_SOURCE_FILE="$ZGENOM_PARENT_DIR/zgenom/zgenom.zsh"
-    fi
+  # Set ZGENOM_SOURCE_FILE to the old directory if it already exists
+  if [[ -f "$ZGENOM_PARENT_DIR/zgenom/zgenom.zsh" ]] ; then
+    ZGENOM_SOURCE_FILE="$ZGENOM_PARENT_DIR/zgenom/zgenom.zsh"
+  fi
 fi
 
 # zgenom stores the clones plugins & themes in $ZGEN_DIR when it
@@ -24,213 +24,213 @@ fi
 ZGEN_DIR=${ZGEN_DIR:-${ZDOTDIR:-$HOME}/.zgenom}
 
 if [[ ! -f "$ZGENOM_SOURCE_FILE" ]] ; then
-    if [[ ! -d "$ZGENOM_PARENT_DIR" ]]; then
-        mkdir -p "$ZGENOM_PARENT_DIR"
-    fi
-    pushd $ZGENOM_PARENT_DIR
-    git clone https://github.com/jandamm/zgenom.git .zqs-zgenom
-    popd
+  if [[ ! -d "$ZGENOM_PARENT_DIR" ]]; then
+    mkdir -p "$ZGENOM_PARENT_DIR"
+  fi
+  pushd $ZGENOM_PARENT_DIR
+  git clone https://github.com/jandamm/zgenom.git .zqs-zgenom
+  popd
 fi
 
 if [[ ! -f "$ZGENOM_SOURCE_FILE" ]] ; then
-    echo "Can't find zgenom.zsh"
+  echo "Can't find zgenom.zsh"
 else
-    # echo "Loading zgenom"
-    source "$ZGENOM_SOURCE_FILE"
+  # echo "Loading zgenom"
+  source "$ZGENOM_SOURCE_FILE"
 fi
 
 unset ZGENOM_PARENT_DIR ZGENOM_SOURCE_FILE
 
 warn-about-prompt-change() {
-    if [[ ! -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-kit-prompt-switch-warning ]]; then
-        echo
-        echo "The default ZSH prompt in the quickstart kit has changed from"
-        echo "bullet-train to powerlevel10k."
-        echo
-        echo "If you want to use the old prompt, run zsh-quickstart-select-bullet-train"
-        echo
-        echo "Run zsh-quickstart-select-powerlevel10k to switch to the new prompt"
-        echo
-        echo "If you do nothing, you will be switched to powerlevel10k"
-        echo
-        touch ${ZDOTDIR:-$HOME}/.zsh-quickstart-kit-prompt-switch-warning
-    fi
+  if [[ ! -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-kit-prompt-switch-warning ]]; then
+    echo
+    echo "The default ZSH prompt in the quickstart kit has changed from"
+    echo "bullet-train to powerlevel10k."
+    echo
+    echo "If you want to use the old prompt, run zsh-quickstart-select-bullet-train"
+    echo
+    echo "Run zsh-quickstart-select-powerlevel10k to switch to the new prompt"
+    echo
+    echo "If you do nothing, you will be switched to powerlevel10k"
+    echo
+    touch ${ZDOTDIR:-$HOME}/.zsh-quickstart-kit-prompt-switch-warning
+  fi
 }
 
 load-starter-plugin-list() {
-    echo "Creating a zgenom save"
-    ZGEN_LOADED=()
-    ZGEN_COMPLETIONS=()
+  echo "Creating a zgenom save"
+  ZGEN_LOADED=()
+  ZGEN_COMPLETIONS=()
 
-    if [[ ! -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-no-omz ]] || [[ $(_zqs-get-setting load-omz-plugins true) == 'true' ]]; then
-        zgenom oh-my-zsh
+  if [[ ! -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-no-omz ]] || [[ $(_zqs-get-setting load-omz-plugins true) == 'true' ]]; then
+    zgenom oh-my-zsh
+  fi
+
+  # If you want to customize your plugin list, create a file named
+  # .zsh-quickstart-local-plugins-example in your home directory. That
+  # file will be sourced during startup *instead* of running this
+  # load-starter-plugin-list function, so make sure to include everything
+  # from this function that you want to keep.
+  #
+  # To make customizing easier, there's a .zsh-quickstart-local-plugins-example
+  # file at the top level of the zsh-quickstart-kit repository that you can
+  # copy as a starting point. This keeps you from having to maintain a fork of
+  # the quickstart kit.
+
+  # If zsh-syntax-highlighting is bundled after zsh-history-substring-search,
+  # they break, so get the order right.
+  zgenom load zdharma-continuum/fast-syntax-highlighting
+  zgenom load zsh-users/zsh-history-substring-search
+
+  # Set keystrokes for substring searching
+  zmodload zsh/terminfo
+  bindkey "$terminfo[kcuu1]" history-substring-search-up
+  bindkey "$terminfo[kcud1]" history-substring-search-down
+
+  # Tab complete rakefile targets.
+  zgenom load unixorn/rake-completion.zshplugin
+
+  # Automatically run zgenom update and zgenom selfupdate every 7 days.
+  zgenom load unixorn/autoupdate-zgenom
+
+  # Add my collection of miscellaneous utility functions.
+  zgenom load unixorn/jpb.zshplugin
+
+  # Colorize the things if you have grc installed. Well, some of the
+  # things, anyway.
+  zgenom load unixorn/warhol.plugin.zsh
+
+  # macOS helpers. This plugin is smart enough to detect when it isn't running
+  # on macOS and not load itself, so you can safely share the same plugin list
+  # across macOS and Linux/BSD.
+  zgenom load unixorn/tumult.plugin.zsh
+
+  # Deal with Apple's squirrelly DNS
+  zgenom load eventi/noreallyjustfuckingstopalready
+
+  # Warn you when you run a command that you've set an alias for without
+  # using the alias.
+  zgenom load djui/alias-tips
+
+  # Add my collection of git helper scripts.
+  zgenom load unixorn/git-extra-commands
+
+  # Add diff-so-fancy so git can use it
+  if [[ "$(_zqs-get-setting diff-so-fancy true)" == 'true' ]]; then
+    zgenom load so-fancy/diff-so-fancy
+  fi
+
+  # Supercharge your history search with fzf
+  zgenom load unixorn/fzf-zsh-plugin
+
+  # Add my bitbucket git helpers plugin.
+  zgenom load unixorn/bitbucket-git-helpers.plugin.zsh
+
+  # A collection of scripts that might be useful to sysadmins.
+  zgenom load skx/sysadmin-util
+
+  # Adds aliases to open your current repo & branch on github.
+  zgenom load peterhurford/git-it-on.zsh
+
+  # Tom Limoncelli's tooling for storing private information (keys, etc)
+  # in a repository securely by encrypting them with gnupg.
+  zgenom load StackExchange/blackbox
+
+  if [[ -f ${ZDOTDIR:-$HOME}/.zqs-add-plugins ]]; then
+    source ${ZDOTDIR:-$HOME}/.zqs-add-plugins
+  fi
+
+  if [[ -d ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d ]]; then
+    load-shell-fragments ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d
+  fi
+
+  if [[ ! -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-no-omz ]] || [[ $(_zqs-get-setting load-omz-plugins false) == 'true' ]]; then
+    # Load some oh-my-zsh plugins
+    zgenom oh-my-zsh plugins/pip
+    zgenom oh-my-zsh plugins/sudo
+    zgenom oh-my-zsh plugins/aws
+    zgenom oh-my-zsh plugins/chruby
+    zgenom oh-my-zsh plugins/colored-man-pages
+    zgenom oh-my-zsh plugins/git
+    zgenom oh-my-zsh plugins/github
+    zgenom oh-my-zsh plugins/python
+    zgenom oh-my-zsh plugins/rsync
+    zgenom oh-my-zsh plugins/screen
+    zgenom oh-my-zsh plugins/vagrant
+
+    if (( $+commands[brew] )); then
+      zgenom oh-my-zsh plugins/brew
     fi
 
-    # If you want to customize your plugin list, create a file named
-    # .zsh-quickstart-local-plugins-example in your home directory. That
-    # file will be sourced during startup *instead* of running this
-    # load-starter-plugin-list function, so make sure to include everything
-    # from this function that you want to keep.
-    #
-    # To make customizing easier, there's a .zsh-quickstart-local-plugins-example
-    # file at the top level of the zsh-quickstart-kit repository that you can
-    # copy as a starting point. This keeps you from having to maintain a fork of
-    # the quickstart kit.
-
-    # If zsh-syntax-highlighting is bundled after zsh-history-substring-search,
-    # they break, so get the order right.
-    zgenom load zdharma-continuum/fast-syntax-highlighting
-    zgenom load zsh-users/zsh-history-substring-search
-
-    # Set keystrokes for substring searching
-    zmodload zsh/terminfo
-    bindkey "$terminfo[kcuu1]" history-substring-search-up
-    bindkey "$terminfo[kcud1]" history-substring-search-down
-
-    # Tab complete rakefile targets.
-    zgenom load unixorn/rake-completion.zshplugin
-
-    # Automatically run zgenom update and zgenom selfupdate every 7 days.
-    zgenom load unixorn/autoupdate-zgenom
-
-    # Add my collection of miscellaneous utility functions.
-    zgenom load unixorn/jpb.zshplugin
-
-    # Colorize the things if you have grc installed. Well, some of the
-    # things, anyway.
-    zgenom load unixorn/warhol.plugin.zsh
-
-    # macOS helpers. This plugin is smart enough to detect when it isn't running
-    # on macOS and not load itself, so you can safely share the same plugin list
-    # across macOS and Linux/BSD.
-    zgenom load unixorn/tumult.plugin.zsh
-
-    # Deal with Apple's squirrelly DNS
-    zgenom load eventi/noreallyjustfuckingstopalready
-
-    # Warn you when you run a command that you've set an alias for without
-    # using the alias.
-    zgenom load djui/alias-tips
-
-    # Add my collection of git helper scripts.
-    zgenom load unixorn/git-extra-commands
-
-    # Add diff-so-fancy so git can use it
-    if [[ "$(_zqs-get-setting diff-so-fancy true)" == 'true' ]]; then
-        zgenom load so-fancy/diff-so-fancy
+    if [ $(uname -a | grep -ci Darwin) = 1 ]; then
+      # Load macOS-specific plugins
+      zgenom oh-my-zsh plugins/macos
     fi
+  fi
 
-    # Supercharge your history search with fzf
-    zgenom load unixorn/fzf-zsh-plugin
+  # A set of shell functions to make it easy to install small apps and
+  # utilities distributed with pip.
+  zgenom load sharat87/pip-app
 
-    # Add my bitbucket git helpers plugin.
-    zgenom load unixorn/bitbucket-git-helpers.plugin.zsh
+  zgenom load chrissicool/zsh-256color
 
-    # A collection of scripts that might be useful to sysadmins.
-    zgenom load skx/sysadmin-util
+  # Load more completion files for zsh from the zsh-lovers github repo.
+  zgenom load zsh-users/zsh-completions src
 
-    # Adds aliases to open your current repo & branch on github.
-    zgenom load peterhurford/git-it-on.zsh
+  # Docker completion
+  zgenom load srijanshetty/docker-zsh
 
-    # Tom Limoncelli's tooling for storing private information (keys, etc)
-    # in a repository securely by encrypting them with gnupg.
-    zgenom load StackExchange/blackbox
+  # Load tab completions for 1Password's op command line tool if it's installed
+  zgenom load unixorn/1password-op.plugin.zsh
 
-    if [[ -f ${ZDOTDIR:-$HOME}/.zqs-add-plugins ]]; then
-        source ${ZDOTDIR:-$HOME}/.zqs-add-plugins
-    fi
+  # Load me last
+  GENCOMPL_FPATH=${ZDOTDIR:-$HOME}/.zsh/complete
 
-    if [[ -d ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d ]]; then
-        load-shell-fragments ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d
-    fi
+  # Very cool plugin that generates zsh completion functions for commands
+  # if they have getopt-style help text. It doesn't generate them on the fly,
+  # you'll have to explicitly generate a completion, but it's still quite cool.
+  zgenom load RobSis/zsh-completion-generator
 
-    if [[ ! -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-no-omz ]] || [[ $(_zqs-get-setting load-omz-plugins false) == 'true' ]]; then
-        # Load some oh-my-zsh plugins
-        zgenom oh-my-zsh plugins/pip
-        zgenom oh-my-zsh plugins/sudo
-        zgenom oh-my-zsh plugins/aws
-        zgenom oh-my-zsh plugins/chruby
-        zgenom oh-my-zsh plugins/colored-man-pages
-        zgenom oh-my-zsh plugins/git
-        zgenom oh-my-zsh plugins/github
-        zgenom oh-my-zsh plugins/python
-        zgenom oh-my-zsh plugins/rsync
-        zgenom oh-my-zsh plugins/screen
-        zgenom oh-my-zsh plugins/vagrant
+  # Add Fish-like autosuggestions to your ZSH.
+  zgenom load zsh-users/zsh-autosuggestions
 
-        if (( $+commands[brew] )); then
-            zgenom oh-my-zsh plugins/brew
-        fi
+  # k is a zsh script / plugin to make directory listings more readable,
+  # adding a bit of color and some git status information on files and
+  # directories.
+  zgenom load supercrabtree/k
 
-        if [ $(uname -a | grep -ci Darwin) = 1 ]; then
-            # Load macOS-specific plugins
-            zgenom oh-my-zsh plugins/macos
-        fi
-    fi
+  # Be compatible with the old settings files for now
+  if [[ -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-use-bullet-train ]] || [[ $(_zqs-get-setting bullet-train false) == 'true' ]]; then
+    # Bullet train prompt setup.
+    zgenom load https://github.com/caiogondim/bullet-train.zsh
+  else
+    # p10k is faster and what I'm using now, so it is the new default
+    zgenom load romkatv/powerlevel10k powerlevel10k
+    warn-about-prompt-change
+  fi
 
-    # A set of shell functions to make it easy to install small apps and
-    # utilities distributed with pip.
-    zgenom load sharat87/pip-app
-
-    zgenom load chrissicool/zsh-256color
-
-    # Load more completion files for zsh from the zsh-lovers github repo.
-    zgenom load zsh-users/zsh-completions src
-
-    # Docker completion
-    zgenom load srijanshetty/docker-zsh
-
-    # Load tab completions for 1Password's op command line tool if it's installed
-    zgenom load unixorn/1password-op.plugin.zsh
-
-    # Load me last
-    GENCOMPL_FPATH=${ZDOTDIR:-$HOME}/.zsh/complete
-
-    # Very cool plugin that generates zsh completion functions for commands
-    # if they have getopt-style help text. It doesn't generate them on the fly,
-    # you'll have to explicitly generate a completion, but it's still quite cool.
-    zgenom load RobSis/zsh-completion-generator
-
-    # Add Fish-like autosuggestions to your ZSH.
-    zgenom load zsh-users/zsh-autosuggestions
-
-    # k is a zsh script / plugin to make directory listings more readable,
-    # adding a bit of color and some git status information on files and
-    # directories.
-    zgenom load supercrabtree/k
-
-    # Be compatible with the old settings files for now
-    if [[ -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-use-bullet-train ]] || [[ $(_zqs-get-setting bullet-train false) == 'true' ]]; then
-        # Bullet train prompt setup.
-        zgenom load https://github.com/caiogondim/bullet-train.zsh
-    else
-        # p10k is faster and what I'm using now, so it is the new default
-        zgenom load romkatv/powerlevel10k powerlevel10k
-        warn-about-prompt-change
-    fi
-
-    # Save it all to init script.
-    zgenom save
+  # Save it all to init script.
+  zgenom save
 }
 
 setup-zgen-repos() {
-    ZQS_override_plugin_list=''
-    # Check the old name for backward compatibility
-    if [[ -r ${ZDOTDIR:-$HOME}/.zgen-local-plugins ]]; then
-        ZQS_override_plugin_list="${ZDOTDIR:-$HOME}/.zgen-local-plugins"
-    fi
-    # If they have both, the new name takes precedence
-    if [[ -r ${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins ]]; then
-        ZQS_override_plugin_list="${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins"
-    fi
+  ZQS_override_plugin_list=''
+  # Check the old name for backward compatibility
+  if [[ -r ${ZDOTDIR:-$HOME}/.zgen-local-plugins ]]; then
+    ZQS_override_plugin_list="${ZDOTDIR:-$HOME}/.zgen-local-plugins"
+  fi
+  # If they have both, the new name takes precedence
+  if [[ -r ${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins ]]; then
+    ZQS_override_plugin_list="${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins"
+  fi
 
-    if [[ -r "$ZQS_override_plugin_list" ]]; then
-        echo "Loading local plugin list from $ZQS_override_plugin_list"
-        source "$ZQS_override_plugin_list"
-        unset ZQS_override_plugin_list
-    else
-        load-starter-plugin-list
-    fi
+  if [[ -r "$ZQS_override_plugin_list" ]]; then
+    echo "Loading local plugin list from $ZQS_override_plugin_list"
+    source "$ZQS_override_plugin_list"
+    unset ZQS_override_plugin_list
+  else
+    load-starter-plugin-list
+  fi
 }
 
 # This comes from https://stackoverflow.com/questions/17878684/best-way-to-get-file-modified-time-in-seconds
@@ -239,24 +239,24 @@ setup-zgen-repos() {
 # Naturally BSD/macOS and Linux can't share the same options to stat.
 if [[ $(uname | grep -ci -e Darwin -e BSD) = 1 ]]; then
 
-    # macOS version.
-    get_file_modification_time() {
-        modified_time=$(stat -f %m "$1" 2> /dev/null) || modified_time=0
-        echo "${modified_time}"
-    }
+  # macOS version.
+  get_file_modification_time() {
+    modified_time=$(stat -f %m "$1" 2> /dev/null) || modified_time=0
+    echo "${modified_time}"
+  }
 
 elif [[ $(uname | grep -ci Linux) = 1 ]]; then
 
-    # Linux version.
-    get_file_modification_time() {
-        modified_time=$(stat -c %Y "$1" 2> /dev/null) || modified_time=0
-        echo "${modified_time}"
-    }
+  # Linux version.
+  get_file_modification_time() {
+    modified_time=$(stat -c %Y "$1" 2> /dev/null) || modified_time=0
+    echo "${modified_time}"
+  }
 fi
 
 # check if there's an init.zsh file for zgen and generate one if not.
 if ! zgenom saved; then
-    setup-zgen-repos
+  setup-zgen-repos
 fi
 
 # Our installation instructions get the user to make a symlink
@@ -267,10 +267,10 @@ fi
 # symlink instead of the target file, so construct a full path to hand off
 # to stat so it returns the modification time of the actual .zgen-setup file.
 if [[ -f ${ZDOTDIR:-$HOME}/.zgen-setup ]]; then
-    REAL_ZGEN_SETUP=${ZDOTDIR:-$HOME}/.zgen-setup
+  REAL_ZGEN_SETUP=${ZDOTDIR:-$HOME}/.zgen-setup
 fi
 if [[ -L ${ZDOTDIR:-$HOME}/.zgen-setup ]]; then
-    REAL_ZGEN_SETUP="$(readlink ${ZDOTDIR:-$HOME}/.zgen-setup)"
+  REAL_ZGEN_SETUP="$(readlink ${ZDOTDIR:-$HOME}/.zgen-setup)"
 fi
 
 # If you don't want my standard starter set of plugins, create a file named
@@ -283,47 +283,47 @@ fi
 # Use readlink in case the user is symlinking from another repo checkout, so
 # they can use a personal dotfiles repository cleanly.
 if [[ -f ${ZDOTDIR:-$HOME}/.zgen-local-plugins ]]; then
-    REAL_ZGEN_SETUP=${ZDOTDIR:-$HOME}/.zgen-local-plugins
+  REAL_ZGEN_SETUP=${ZDOTDIR:-$HOME}/.zgen-local-plugins
 fi
 if [[ -L ${ZDOTDIR:-$HOME}/.zgen-local-plugins ]]; then
-    REAL_ZGEN_SETUP="${ZDOTDIR:-$HOME}/$(readlink ${ZDOTDIR:-$HOME}/.zgen-local-plugins)"
+  REAL_ZGEN_SETUP="${ZDOTDIR:-$HOME}/$(readlink ${ZDOTDIR:-$HOME}/.zgen-local-plugins)"
 fi
 # Old file still works for backward compatibility, but we want the new file
 # to take precedence when both exist.
 if [[ -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins ]]; then
-    REAL_ZGEN_SETUP=${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins
+  REAL_ZGEN_SETUP=${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins
 fi
 if [[ -L ${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins ]]; then
-    REAL_ZGEN_SETUP="${ZDOTDIR:-$HOME}/$(readlink ${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins)"
+  REAL_ZGEN_SETUP="${ZDOTDIR:-$HOME}/$(readlink ${ZDOTDIR:-$HOME}/.zsh-quickstart-local-plugins)"
 fi
 
 # If .zgen-setup is newer than init.zsh, regenerate init.zsh
 if [ $(get_file_modification_time ${REAL_ZGEN_SETUP}) -gt $(get_file_modification_time ${ZDOTDIR:-$HOME}/.zgenom/init.zsh) ]; then
-    echo "$(basename ${REAL_ZGEN_SETUP}) ($REAL_ZGEN_SETUP) updated; creating a new init.zsh from plugin list in ${REAL_ZGEN_SETUP}"
-    setup-zgen-repos
+  echo "$(basename ${REAL_ZGEN_SETUP}) ($REAL_ZGEN_SETUP) updated; creating a new init.zsh from plugin list in ${REAL_ZGEN_SETUP}"
+  setup-zgen-repos
 elif [ -d ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d ]; then
-    init_timestamp=$(get_file_modification_time ${ZDOTDIR:-$HOME}/.zgenom/init.zsh)
-    plugins_dir_timestamp=$(get_file_modification_time ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d)
-    if [ "$plugins_dir_timestamp" -gt "$init_timestamp" ]; then
+  init_timestamp=$(get_file_modification_time ${ZDOTDIR:-$HOME}/.zgenom/init.zsh)
+  plugins_dir_timestamp=$(get_file_modification_time ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d)
+  if [ "$plugins_dir_timestamp" -gt "$init_timestamp" ]; then
+    need_update="true"
+  fi
+
+  if [[ -n "$("ls" -A ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d)" ]] && [[ -z ${need_update-} ]]; then
+    for file in ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d/*; do
+      if [[ $(get_file_modification_time "${file}") -gt ${init_timestamp} ]]; then
         need_update="true"
-    fi
+        break
+      fi
+    done
+  fi
 
-    if [[ -n "$("ls" -A ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d)" ]] && [[ -z ${need_update-} ]]; then
-        for file in ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d/*; do
-            if [[ $(get_file_modification_time "${file}") -gt ${init_timestamp} ]]; then
-                need_update="true"
-                break
-            fi
-        done
-    fi
-
-    if [[ -n ${need_update-} ]]; then
-        echo "Some files in ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d updated; creating a new init.zsh from plugin list in ${REAL_ZGEN_SETUP} and plugins dir"
-        setup-zgen-repos
-    fi
-    unset init_timestamp
-    unset plugins_dir_timestamp
-    unset need_update
+  if [[ -n ${need_update-} ]]; then
+    echo "Some files in ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d updated; creating a new init.zsh from plugin list in ${REAL_ZGEN_SETUP} and plugins dir"
+    setup-zgen-repos
+  fi
+  unset init_timestamp
+  unset plugins_dir_timestamp
+  unset need_update
 fi
 
 unset REAL_ZGEN_SETUP

--- a/zsh/.zsh_aliases
+++ b/zsh/.zsh_aliases
@@ -12,25 +12,25 @@
 # own fork of the quickstart kit.
 
 if [[ -d ~/gocode ]]; then
-    export GOPATH=~/gocode
+  export GOPATH=~/gocode
 fi
 
 # Yes, these tests are ugly. They do however, work.
 if [[ "$(uname -s)" == "Darwin" ]]; then
-    # do macOS specific things
-    alias top="TERM=vt100 top"
+  # do macOS specific things
+  alias top="TERM=vt100 top"
 else
-    alias cputop="top -o cpu"
-    alias l-d="ls -lad"
-    alias l="ls -lah"
-    alias ll="ls -lah | less"
+  alias cputop="top -o cpu"
+  alias l-d="ls -lad"
+  alias l="ls -lah"
+  alias ll="ls -lah | less"
 fi
 
 if [[ "$(uname -s)" == "Linux" ]]; then
-    # we're on linux
-    alias l-d="ls -lFad"
-    alias l="ls -laF"
-    alias ll="ls -lFa | TERM=vt100 less"
+  # we're on linux
+  alias l-d="ls -lFad"
+  alias l="ls -laF"
+  alias ll="ls -lFa | TERM=vt100 less"
 fi
 
 export CVS_RSH=ssh
@@ -39,39 +39,39 @@ export CVS_RSH=ssh
 alias historysummary="history | awk '{a[\$2]++} END{for(i in a){printf \"%5d\t%s\n\",a[i],i}}' | sort -rn | head"
 
 if [ -x /bin/vim ]; then
-    alias vi="/bin/vim"
-    alias vim="/bin/vim"
-    export EDITOR="/bin/vim"
+  alias vi="/bin/vim"
+  alias vim="/bin/vim"
+  export EDITOR="/bin/vim"
 fi
 
 if [ -x /usr/bin/vim ]; then
-    alias vi="/usr/bin/vim"
-    alias vim="/usr/bin/vim"
-    export EDITOR="/usr/bin/vim"
+  alias vi="/usr/bin/vim"
+  alias vim="/usr/bin/vim"
+  export EDITOR="/usr/bin/vim"
 fi
 
 # MacPorts has a newer vim than Apple ships
 if [ -x /opt/local/bin/vim ]; then
-    alias vim="/opt/local/bin/vim"
-    alias vi="/opt/local/bin/vim"
-    export EDITOR="/opt/local/bin/vim"
+  alias vim="/opt/local/bin/vim"
+  alias vi="/opt/local/bin/vim"
+  export EDITOR="/opt/local/bin/vim"
 fi
 
 # So does brew
 if can_haz brew; then
-    brew_prefix="$(brew --prefix)/bin"
-    if [[ -x "$brew_prefix/vim" ]]; then
-        alias vim="$brew_prefix/vim"
-        alias vi="$brew_prefix/vim"
-        export EDITOR="$brew_prefix/vim"
-    fi
-    unset brew_prefix
+  brew_prefix="$(brew --prefix)/bin"
+  if [[ -x "$brew_prefix/vim" ]]; then
+    alias vim="$brew_prefix/vim"
+    alias vi="$brew_prefix/vim"
+    export EDITOR="$brew_prefix/vim"
+  fi
+  unset brew_prefix
 fi
 
 # Clearly, I really like vim.
 
 if (( ${+EDITOR} )); then
-    export VISUAL="${EDITOR}"
+  export VISUAL="${EDITOR}"
 fi
 
 # Clean up files that have the wrong line endings
@@ -147,14 +147,14 @@ fi
 
 # Use brew versions if present
 if can_haz brew; then
-    brew_prefix=$(brew --prefix)
-    if [ -x "${brew_prefix}/bin/mysql/bin/mysql" ]; then
-        alias mysql="${brew_prefix}/mysql/bin/mysql"
-    fi
+  brew_prefix=$(brew --prefix)
+  if [ -x "${brew_prefix}/bin/mysql/bin/mysql" ]; then
+    alias mysql="${brew_prefix}/mysql/bin/mysql"
+  fi
 
-    if [ -x "${brew_prefix}/bin/mysql/bin/mysqladmin" ]; then
-        alias mysqladmin="${brew_prefix}/mysql/bin/mysqladmin"
-    fi
+  if [ -x "${brew_prefix}/bin/mysql/bin/mysqladmin" ]; then
+    alias mysqladmin="${brew_prefix}/mysql/bin/mysqladmin"
+  fi
 fi
 
 # Help the lazy typists again.
@@ -163,8 +163,8 @@ alias ...="cd ../.."
 
 # Honor old .zsh_aliases.local customizations, but print depecation warning.
 if [ -f ${ZDOTDIR:-$HOME}/.zsh_aliases.local ]; then
-    # shellcheck disable=SC1090
-    source ${ZDOTDIR:-$HOME}/.zsh_aliases.local
-    echo ".zsh_aliases.local is deprecated and will stop working after June 1st, 2022."
-    echo "Make entries in ${ZDOTDIR:-$HOME}/.zshrc.d instead. See https://github.com/unixorn/zsh-quickstart-kit#zshrcd for more details."
+  # shellcheck disable=SC1090
+  source ${ZDOTDIR:-$HOME}/.zsh_aliases.local
+  echo ".zsh_aliases.local is deprecated and will stop working after June 1st, 2022."
+  echo "Make entries in ${ZDOTDIR:-$HOME}/.zshrc.d instead. See https://github.com/unixorn/zsh-quickstart-kit#zshrcd for more details."
 fi

--- a/zsh/.zsh_aliases
+++ b/zsh/.zsh_aliases
@@ -12,25 +12,25 @@
 # own fork of the quickstart kit.
 
 if [[ -d ~/gocode ]]; then
-  export GOPATH=~/gocode
+    export GOPATH=~/gocode
 fi
 
 # Yes, these tests are ugly. They do however, work.
 if [[ "$(uname -s)" == "Darwin" ]]; then
-  # do macOS specific things
-  alias top="TERM=vt100 top"
+    # do macOS specific things
+    alias top="TERM=vt100 top"
 else
-  alias cputop="top -o cpu"
-  alias l-d="ls -lad"
-  alias l="ls -lah"
-  alias ll="ls -lah | less"
+    alias cputop="top -o cpu"
+    alias l-d="ls -lad"
+    alias l="ls -lah"
+    alias ll="ls -lah | less"
 fi
 
 if [[ "$(uname -s)" == "Linux" ]]; then
-  # we're on linux
-  alias l-d="ls -lFad"
-  alias l="ls -laF"
-  alias ll="ls -lFa | TERM=vt100 less"
+    # we're on linux
+    alias l-d="ls -lFad"
+    alias l="ls -laF"
+    alias ll="ls -lFa | TERM=vt100 less"
 fi
 
 export CVS_RSH=ssh
@@ -59,18 +59,20 @@ fi
 
 # So does brew
 if can_haz brew; then
-  brew_prefix="$(brew --prefix)/bin"
-  if [[ -x "$brew_prefix/vim" ]]; then
-      alias vim="$brew_prefix/vim"
-      alias vi="$brew_prefix/vim"
-      export EDITOR="$brew_prefix/vim"
-  fi
-  unset brew_prefix
+    brew_prefix="$(brew --prefix)/bin"
+    if [[ -x "$brew_prefix/vim" ]]; then
+        alias vim="$brew_prefix/vim"
+        alias vi="$brew_prefix/vim"
+        export EDITOR="$brew_prefix/vim"
+    fi
+    unset brew_prefix
 fi
 
 # Clearly, I really like vim.
 
-export VISUAL=${EDITOR}
+if (( ${+EDITOR} )); then
+    export VISUAL="${EDITOR}"
+fi
 
 # Clean up files that have the wrong line endings
 alias mac2unix="tr '\015' '\012'"
@@ -120,9 +122,9 @@ alias wget="wget -c"
 alias zh="fc -l -d -D"
 
 # My typical tyops.
+alias grep='GREP_COLORS="1;37;41" LANG=C grep --color=auto'
 alias gerp='grep'
 alias grep-i='grep -i'
-alias grep='GREP_COLORS="1;37;41" LANG=C grep --color=auto'
 alias grepi='grep -i'
 alias knfie='knife'
 alias maek='make'
@@ -145,14 +147,14 @@ fi
 
 # Use brew versions if present
 if can_haz brew; then
-  brew_prefix=$(brew --prefix)
-  if [ -x "${brew_prefix}/bin/mysql/bin/mysql" ]; then
-    alias mysql="${brew_prefix}/mysql/bin/mysql"
-  fi
+    brew_prefix=$(brew --prefix)
+    if [ -x "${brew_prefix}/bin/mysql/bin/mysql" ]; then
+        alias mysql="${brew_prefix}/mysql/bin/mysql"
+    fi
 
-  if [ -x "${brew_prefix}/bin/mysql/bin/mysqladmin" ]; then
-    alias mysqladmin="${brew_prefix}/mysql/bin/mysqladmin"
-  fi
+    if [ -x "${brew_prefix}/bin/mysql/bin/mysqladmin" ]; then
+        alias mysqladmin="${brew_prefix}/mysql/bin/mysqladmin"
+    fi
 fi
 
 # Help the lazy typists again.
@@ -160,9 +162,9 @@ alias ..="cd .."
 alias ...="cd ../.."
 
 # Honor old .zsh_aliases.local customizations, but print depecation warning.
-if [ -f ~/.zsh_aliases.local ]; then
-  # shellcheck disable=SC1090
-  source ~/.zsh_aliases.local
-  echo ".zsh_aliases.local is deprecated and will stop working after June 1st, 2022."
-  echo "Make entries in ~/.zshrc.d instead. See https://github.com/unixorn/zsh-quickstart-kit#zshrcd for more details."
+if [ -f ${ZDOTDIR:-$HOME}/.zsh_aliases.local ]; then
+    # shellcheck disable=SC1090
+    source ${ZDOTDIR:-$HOME}/.zsh_aliases.local
+    echo ".zsh_aliases.local is deprecated and will stop working after June 1st, 2022."
+    echo "Make entries in ${ZDOTDIR:-$HOME}/.zshrc.d instead. See https://github.com/unixorn/zsh-quickstart-kit#zshrcd for more details."
 fi

--- a/zsh/.zsh_functions
+++ b/zsh/.zsh_functions
@@ -47,119 +47,119 @@ function man() {
     LESS_TERMCAP_so=$(printf "\e[1;44;33m") \
     LESS_TERMCAP_ue=$(printf "\e[0m") \
     LESS_TERMCAP_us=$(printf "\e[1;32m") \
-      man "$@"
+    man "$@"
 }
 
 if ! can_haz watch; then
-    # From commandlinefu.com
-    function watch () {
-        t="$1"
-        shift
-        while test :
-        do
-            clear
-            date=$(date)
-            echo -e "Every $ts: $@ \t\t\t\t $date"
-            $@
-            sleep "$t"
-        done
-    }
+  # From commandlinefu.com
+  function watch () {
+    t="$1"
+    shift
+    while test :
+    do
+      clear
+      date=$(date)
+      echo -e "Every $ts: $@ \t\t\t\t $date"
+      $@
+      sleep "$t"
+    done
+  }
 fi
 
 # scp file to machine you're sshing into this machine from
 function mecp() {
-    scp "$@" ${SSH_CLIENT%% *}:~/Downloads/;
+  scp "$@" ${SSH_CLIENT%% *}:~/Downloads/;
 }
 
 function calc() {
-    awk "BEGIN{ print $* }" ;
+  awk "BEGIN{ print $* }" ;
 }
 
 function get-nr-jobs() {
-    jobs | wc -l
+  jobs | wc -l
 }
 alias get_nr_jobs="get-nr-jobs"
 
 function get_load() {
-    uptime | awk '{print $11}' | tr ',' ' '
+  uptime | awk '{print $11}' | tr ',' ' '
 }
 
 function mtr-url() {
-    if can_haz mtr; then
-        host=$(ruby -ruri -e "puts (URI.parse('$1').host or '$1')")
-        sudo mtr -t "$host"
-    else
-        echo 'Cannot find mtr in your PATH - install it and try again'
-    fi
+  if can_haz mtr; then
+    host=$(ruby -ruri -e "puts (URI.parse('$1').host or '$1')")
+    sudo mtr -t "$host"
+  else
+    echo 'Cannot find mtr in your PATH - install it and try again'
+  fi
 }
 alias mtr_url="mtr-url"
 
 function fix_tmux_ssh_agent() {
-    if can_haz tmux; then
-        for key in SSH_AUTH_SOCK SSH_CONNECTION SSH_CLIENT; do
-        if (tmux show-environment | grep "^${key}" > /dev/null); then
-            value=$(tmux show-environment | grep "^${key}" | sed -e "s/^[A-Z_]*=//")
-            export ${key}="${value}"
-        fi
-        done
-    else
-        echo "Can't find tmux in your PATH. Install it and try again."
+  if can_haz tmux; then
+    for key in SSH_AUTH_SOCK SSH_CONNECTION SSH_CLIENT; do
+    if (tmux show-environment | grep "^${key}" > /dev/null); then
+      value=$(tmux show-environment | grep "^${key}" | sed -e "s/^[A-Z_]*=//")
+      export ${key}="${value}"
     fi
+    done
+  else
+    echo "Can't find tmux in your PATH. Install it and try again."
+  fi
 }
 
 function scan24() {
-    if can_haz nmap; then
-        # Probe a /24 for hosts
-        nmap -sP ${1}/24
-    else
-        echo "Can't find nmap in your PATH - install it and try again."
-    fi
+  if can_haz nmap; then
+    # Probe a /24 for hosts
+    nmap -sP ${1}/24
+  else
+    echo "Can't find nmap in your PATH - install it and try again."
+  fi
 }
 
 if ! can_haz nj; then
-    # Netjoin - Block until a network connection is obtained.
-    # Originally from https://github.com/bamos/dotfiles/blob/master/.funcs
-    function nj() {
-        while true; do
-        ping -c 1 8.8.8.8 &> /dev/null && break
-        sleep 1
-        done
-    }
+  # Netjoin - Block until a network connection is obtained.
+  # Originally from https://github.com/bamos/dotfiles/blob/master/.funcs
+  function nj() {
+    while true; do
+      ping -c 1 8.8.8.8 &> /dev/null && break
+      sleep 1
+    done
+  }
 fi
 
 # lists zombie processes
 function zombie() {
-    ps aux | awk '{if ($8=="Z") { print $2 }}'
+  ps aux | awk '{if ($8=="Z") { print $2 }}'
 }
 alias zombies=zombie
 
 # get the content type of an http resource
 # from https://github.com/jleclanche/dotfiles/blob/master/.zshrc
 function htmime() {
-    if [[ -z $1 ]]; then
-        print "USAGE: htmime <URL>"
-        return 1
-    fi
-    if can_haz curl; then
-        mime=$(curl -sIX HEAD $1 | sed -nr "s/Content-Type: (.+)/\1/p")
-    else
-        echo "Can't find curl in your PATH"
-    fi
-    print $mime
+  if [[ -z $1 ]]; then
+    print "USAGE: htmime <URL>"
+    return 1
+  fi
+  if can_haz curl; then
+    mime=$(curl -sIX HEAD $1 | sed -nr "s/Content-Type: (.+)/\1/p")
+  else
+    echo "Can't find curl in your PATH"
+  fi
+  print $mime
 }
 
 # Start an HTTP server from a directory, optionally specifying the port
 function httpserver() {
-    local port="${1:-8000}";
-    sleep 1 && open "http://localhost:${port}/" &
-    # Set the default Content-Type to `text/plain` instead of `application/octet-stream`
-    # And serve everything as UTF-8 (although not technically correct, this doesn’t break anything for binary files)
-    python -c $'import SimpleHTTPServer;\nmap = SimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map;\nmap[""] = "text/plain";\nfor key, value in map.items():\n\tmap[key] = value + ";charset=UTF-8";\nSimpleHTTPServer.test();' "$port";
+  local port="${1:-8000}";
+  sleep 1 && open "http://localhost:${port}/" &
+  # Set the default Content-Type to `text/plain` instead of `application/octet-stream`
+  # And serve everything as UTF-8 (although not technically correct, this doesn’t break anything for binary files)
+  python -c $'import SimpleHTTPServer;\nmap = SimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map;\nmap[""] = "text/plain";\nfor key, value in map.items():\n\tmap[key] = value + ";charset=UTF-8";\nSimpleHTTPServer.test();' "$port";
 }
 
 # Honor old .zsh_functions.local customizations, but print depecation warning.
 if [ -f ${ZDOTDIR:-$HOME}/.zsh_functions.local ]; then
-    source ${ZDOTDIR:-$HOME}/.zsh_functions.local
-    echo ".zsh_functions.local is deprecated and will stop working after June 1st, 2022."
-    echo "Make entries in ${ZDOTDIR:-$HOME}/.zshrc.d instead. See https://github.com/unixorn/zsh-quickstart-kit#zshrcd for more details."
+  source ${ZDOTDIR:-$HOME}/.zsh_functions.local
+  echo ".zsh_functions.local is deprecated and will stop working after June 1st, 2022."
+  echo "Make entries in ${ZDOTDIR:-$HOME}/.zshrc.d instead. See https://github.com/unixorn/zsh-quickstart-kit#zshrcd for more details."
 fi

--- a/zsh/.zsh_functions
+++ b/zsh/.zsh_functions
@@ -51,115 +51,115 @@ function man() {
 }
 
 if ! can_haz watch; then
-  # From commandlinefu.com
-  function watch () {
-    t="$1"
-    shift
-    while test :
-    do
-      clear
-      date=$(date)
-      echo -e "Every $ts: $@ \t\t\t\t $date"
-      $@
-      sleep "$t"
-    done
-  }
+    # From commandlinefu.com
+    function watch () {
+        t="$1"
+        shift
+        while test :
+        do
+            clear
+            date=$(date)
+            echo -e "Every $ts: $@ \t\t\t\t $date"
+            $@
+            sleep "$t"
+        done
+    }
 fi
 
 # scp file to machine you're sshing into this machine from
 function mecp() {
-  scp "$@" ${SSH_CLIENT%% *}:~/Downloads/;
+    scp "$@" ${SSH_CLIENT%% *}:~/Downloads/;
 }
 
 function calc() {
-  awk "BEGIN{ print $* }" ;
+    awk "BEGIN{ print $* }" ;
 }
 
 function get-nr-jobs() {
-  jobs | wc -l
+    jobs | wc -l
 }
 alias get_nr_jobs="get-nr-jobs"
 
 function get_load() {
-  uptime | awk '{print $11}' | tr ',' ' '
+    uptime | awk '{print $11}' | tr ',' ' '
 }
 
 function mtr-url() {
-  if can_haz mtr; then
-    host=$(ruby -ruri -e "puts (URI.parse('$1').host or '$1')")
-    sudo mtr -t "$host"
-  else
-    echo 'Cannot find mtr in your PATH - install it and try again'
-  fi
+    if can_haz mtr; then
+        host=$(ruby -ruri -e "puts (URI.parse('$1').host or '$1')")
+        sudo mtr -t "$host"
+    else
+        echo 'Cannot find mtr in your PATH - install it and try again'
+    fi
 }
 alias mtr_url="mtr-url"
 
 function fix_tmux_ssh_agent() {
-  if can_haz tmux; then
-    for key in SSH_AUTH_SOCK SSH_CONNECTION SSH_CLIENT; do
-      if (tmux show-environment | grep "^${key}" > /dev/null); then
-        value=$(tmux show-environment | grep "^${key}" | sed -e "s/^[A-Z_]*=//")
-        export ${key}="${value}"
-      fi
-    done
-  else
-    echo "Can't find tmux in your PATH. Install it and try again."
-  fi
+    if can_haz tmux; then
+        for key in SSH_AUTH_SOCK SSH_CONNECTION SSH_CLIENT; do
+        if (tmux show-environment | grep "^${key}" > /dev/null); then
+            value=$(tmux show-environment | grep "^${key}" | sed -e "s/^[A-Z_]*=//")
+            export ${key}="${value}"
+        fi
+        done
+    else
+        echo "Can't find tmux in your PATH. Install it and try again."
+    fi
 }
 
 function scan24() {
-  if can_haz nmap; then
-    # Probe a /24 for hosts
-    nmap -sP ${1}/24
-  else
-    echo "Can't find nmap in your PATH - install it and try again."
-  fi
+    if can_haz nmap; then
+        # Probe a /24 for hosts
+        nmap -sP ${1}/24
+    else
+        echo "Can't find nmap in your PATH - install it and try again."
+    fi
 }
 
 if ! can_haz nj; then
-  # Netjoin - Block until a network connection is obtained.
-  # Originally from https://github.com/bamos/dotfiles/blob/master/.funcs
-  function nj() {
-    while true; do
-      ping -c 1 8.8.8.8 &> /dev/null && break
-      sleep 1
-    done
-  }
+    # Netjoin - Block until a network connection is obtained.
+    # Originally from https://github.com/bamos/dotfiles/blob/master/.funcs
+    function nj() {
+        while true; do
+        ping -c 1 8.8.8.8 &> /dev/null && break
+        sleep 1
+        done
+    }
 fi
 
 # lists zombie processes
 function zombie() {
-  ps aux | awk '{if ($8=="Z") { print $2 }}'
+    ps aux | awk '{if ($8=="Z") { print $2 }}'
 }
 alias zombies=zombie
 
 # get the content type of an http resource
 # from https://github.com/jleclanche/dotfiles/blob/master/.zshrc
 function htmime() {
-  if [[ -z $1 ]]; then
-    print "USAGE: htmime <URL>"
-    return 1
-  fi
-  if can_haz curl; then
-    mime=$(curl -sIX HEAD $1 | sed -nr "s/Content-Type: (.+)/\1/p")
-  else
-    echo "Can't find curl in your PATH"
-  fi
-  print $mime
+    if [[ -z $1 ]]; then
+        print "USAGE: htmime <URL>"
+        return 1
+    fi
+    if can_haz curl; then
+        mime=$(curl -sIX HEAD $1 | sed -nr "s/Content-Type: (.+)/\1/p")
+    else
+        echo "Can't find curl in your PATH"
+    fi
+    print $mime
 }
 
 # Start an HTTP server from a directory, optionally specifying the port
 function httpserver() {
-  local port="${1:-8000}";
-  sleep 1 && open "http://localhost:${port}/" &
-  # Set the default Content-Type to `text/plain` instead of `application/octet-stream`
-  # And serve everything as UTF-8 (although not technically correct, this doesn’t break anything for binary files)
-  python -c $'import SimpleHTTPServer;\nmap = SimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map;\nmap[""] = "text/plain";\nfor key, value in map.items():\n\tmap[key] = value + ";charset=UTF-8";\nSimpleHTTPServer.test();' "$port";
+    local port="${1:-8000}";
+    sleep 1 && open "http://localhost:${port}/" &
+    # Set the default Content-Type to `text/plain` instead of `application/octet-stream`
+    # And serve everything as UTF-8 (although not technically correct, this doesn’t break anything for binary files)
+    python -c $'import SimpleHTTPServer;\nmap = SimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map;\nmap[""] = "text/plain";\nfor key, value in map.items():\n\tmap[key] = value + ";charset=UTF-8";\nSimpleHTTPServer.test();' "$port";
 }
 
 # Honor old .zsh_functions.local customizations, but print depecation warning.
-if [ -f ~/.zsh_functions.local ]; then
-  source .zsh_functions.local
-  echo ".zsh_functions.local is deprecated and will stop working after June 1st, 2022."
-  echo "Make entries in ~/.zshrc.d instead. See https://github.com/unixorn/zsh-quickstart-kit#zshrcd for more details."
+if [ -f ${ZDOTDIR:-$HOME}/.zsh_functions.local ]; then
+    source ${ZDOTDIR:-$HOME}/.zsh_functions.local
+    echo ".zsh_functions.local is deprecated and will stop working after June 1st, 2022."
+    echo "Make entries in ${ZDOTDIR:-$HOME}/.zshrc.d instead. See https://github.com/unixorn/zsh-quickstart-kit#zshrcd for more details."
 fi

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -20,7 +20,7 @@
 # All files in there will be sourced, and keeping your customizations
 # there will keep you from having to maintain a separate fork of the
 # quickstart kit.
-if [[ -f ~/.zqs-zprof-enabled ]]; then
+if [[ -f ${ZDOTDIR:-$HOME}/.zqs-zprof-enabled ]]; then
   zmodload zsh/zprof
 fi
 
@@ -30,7 +30,7 @@ function can_haz() {
 }
 
 function zqs-debug() {
-  if [[ -f ~/.zqs-debug-mode ]]; then
+  if [[ -f ${ZDOTDIR:-$HOME}/.zqs-debug-mode ]]; then
     echo $@
   fi
 }
@@ -57,10 +57,10 @@ fi
 export COMPLETION_WAITING_DOTS="true"
 
 # Provide a unified way for the quickstart to get/set settings.
-if [[ -f ~/.zqs-settings-path ]]; then
-  _ZQS_SETTINGS_DIR=$(cat ~/.zqs-settings-path)
+if [[ -f ${ZDOTDIR:-$HOME}/.zqs-settings-path ]]; then
+  _ZQS_SETTINGS_DIR=$(cat ${ZDOTDIR:-$HOME}/.zqs-settings-path)
 else
-  _ZQS_SETTINGS_DIR="${HOME}/.zqs-settings"
+  _ZQS_SETTINGS_DIR="${ZDOTDIR:-$HOME}/.zqs-settings"
 fi
 export _ZQS_SETTINGS_DIR
 
@@ -74,15 +74,15 @@ _zqs-trigger-init-rebuild() {
 
 # We need to load shell fragment files often enough to make it a function
 function load-shell-fragments() {
-  if [[ -z $1 ]]; then
+  if [[ -z ${1-} ]]; then
     echo "You must give load-shell-fragments a directory path"
   else
     if [[ -d "$1" ]]; then
-      if [ -n "$(/bin/ls -A $1)" ]; then
-        for _zqs_fragment in $(/bin/ls -A $1)
+      if [ -n "$(/bin/ls -A "$1")" ]; then
+        for _zqs_fragment in $(/bin/ls -A "$1")
         do
-          if [ -r $1/$_zqs_fragment ]; then
-            source $1/$_zqs_fragment
+          if [ -r "$1/$_zqs_fragment" ]; then
+            source "$1/$_zqs_fragment"
           fi
         done
         unset _zqs_fragment
@@ -139,25 +139,25 @@ _zqs-purge-setting() {
 # Convert the old settings files into new style settings
 function _zqs-update-stale-settings-files() {
   # Convert .zqs-additional-plugins to new format
-  if [[ -f ~/.zqs-additional-plugins ]]; then
-    mkdir -p ~/.zshrc.add-plugins.d
-    sed -e 's/^./zgenom load &/' ~/.zqs-additional-plugins >> ~/.zshrc.add-plugins.d/0000-transferred-plugins
-    rm -f ~/.zqs-additional-plugins
+  if [[ -f ${ZDOTDIR:-$HOME}/.zqs-additional-plugins ]]; then
+    mkdir -p ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d
+    sed -e 's/^./zgenom load &/' ${ZDOTDIR:-$HOME}/.zqs-additional-plugins >> ${ZDOTDIR:-$HOME}/.zshrc.add-plugins.d/0000-transferred-plugins
+    rm -f ${ZDOTDIR:-$HOME}/.zqs-additional-plugins
     echo "Plugins from .zqs-additional-plugins were moved to .zshrc.add-plugins.d/0000-transferred-plugins with a format change"
   fi
-  if [[ -f ~/.zsh-quickstart-use-bullet-train ]]; then
+  if [[ -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-use-bullet-train ]]; then
     _zqs-set-setting bullet-train true
-    rm -f ~/.zsh-quickstart-use-bullet-train
+    rm -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-use-bullet-train
     echo "Converted old ~/.zsh-quickstart-use-bullet-train to new settings system"
   fi
-  if [[ -f ~/.zsh-quickstart-no-omz ]]; then
+  if [[ -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-no-omz ]]; then
     _zqs-set-setting load-omz-plugins false
-    rm -f ~/.zsh-quickstart-no-omz
+    rm -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-no-omz
     echo "Converted old ~/.zsh-quickstart-no-omz to new settings system"
   fi
-  if [[ -f ~/.zsh-quickstart-no-zmv ]]; then
+  if [[ -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-no-zmv ]]; then
     _zqs-set-setting no-zmv true
-    rm -f ~/.zsh-quickstart-no-zmv
+    rm -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-no-zmv
     echo "Converted old ~/.zsh-quickstart-no-zmv to new settings system"
   fi
   # Don't break existing user setups, but transition to a zqs setting to reduce
@@ -321,10 +321,10 @@ fi
 # tool that makes it easy to customize your color scheme and keep them in sync
 # across Linux and OS X/*BSD at http://geoff.greer.fm/lscolors/
 
-if [[ -z "$LSCOLORS" ]]; then
+if [[ -z ${LSCOLORS-} ]]; then
   export LSCOLORS='Exfxcxdxbxegedabagacad'
 fi
-if [[ -z "$LS_COLORS" ]]; then
+if [[ -z ${LS_COLORS-} ]]; then
   export LS_COLORS='di=1;34;40:ln=35;40:so=32;40:pi=33;40:ex=31;40:bd=34;46:cd=34;43:su=0;41:sg=0;46:tw=0;42:ow=0;43:'
 fi
 
@@ -409,7 +409,7 @@ load-our-ssh-keys() {
   fi
 }
 
-if [[ -z "$SSH_CLIENT" ]] || can_haz keychain; then
+if [[ -z ${SSH_CLIENT-} ]] || can_haz keychain; then
   # We're not on a remote machine, so load keys
   if [[ "$(_zqs-get-setting enable-ssh-askpass-require)" == 'true' ]]; then
     zsh-quickstart-set-ssh-askpass-require
@@ -422,18 +422,18 @@ if [[ -z "$SSH_CLIENT" ]] || can_haz keychain; then
 fi
 
 # Load helper functions before we load zgenom setup
-if [ -r ~/.zsh_functions ]; then
-  source ~/.zsh_functions
+if [ -r ${ZDOTDIR:-$HOME}/.zsh_functions ]; then
+  source ${ZDOTDIR:-$HOME}/.zsh_functions
 fi
 
 # Make it easy to prepend your own customizations that override
 # the quickstart kit's defaults by loading all files from the
 # ~/.zshrc.pre-plugins.d directory
-mkdir -p ~/.zshrc.pre-plugins.d
-load-shell-fragments ~/.zshrc.pre-plugins.d
+mkdir -p ${ZDOTDIR:-$HOME}/.zshrc.pre-plugins.d
+load-shell-fragments ${ZDOTDIR:-$HOME}/.zshrc.pre-plugins.d
 
-if [[ -d "$HOME/.zshrc.pre-plugins.$(uname).d" ]]; then
-  load-shell-fragments "$HOME/.zshrc.pre-plugins.$(uname).d"
+if [[ -d "${ZDOTDIR:-$HOME}/.zshrc.pre-plugins.$(uname).d" ]]; then
+  load-shell-fragments "${ZDOTDIR:-$HOME}/.zshrc.pre-plugins.$(uname).d"
 fi
 
 # macOS doesn't have a python by default. This makes the omz python and
@@ -445,7 +445,7 @@ if ! can_haz python; then
   fi
   # Ugly hack for zsh-completion-generator - but only do it if the user
   # hasn't already set GENCOMPL_PY
-  if [[ -z "$GENCOMPL_PY" ]]; then
+  if [[ -z ${GENCOMPL_PY-} ]]; then
     export GENCOMPL_PY='python3'
     export ZSH_COMPLETION_HACK='true'
   fi
@@ -453,13 +453,13 @@ fi
 
 # Now that we have $PATH set up and ssh keys loaded, configure zgenom.
 # Start zgenom
-if [ -f ~/.zgen-setup ]; then
-  source ~/.zgen-setup
+if [ -f ${ZDOTDIR:-$HOME}/.zgen-setup ]; then
+  source ${ZDOTDIR:-$HOME}/.zgen-setup
 fi
 
 # Undo the hackery for issue 180
 # Don't unset GENCOMPL_PY if we didn't set it
-if [[ -n "$ZSH_COMPLETION_HACK" ]]; then
+if [[ -n ${ZSH_COMPLETION_HACK-} ]]; then
   unset GENCOMPL_PY
   unset ZSH_COMPLETION_HACK
 fi
@@ -490,7 +490,7 @@ setopt share_history
 # adding a file to ~/.zshrc.d that changes these variables.
 export HISTSIZE=100000
 export SAVEHIST=100000
-HISTFILE=~/.zsh_history
+HISTFILE=${ZDOTDIR:-$HOME}/.zsh_history
 
 # ZSH Man page referencing the history_ignore parameter - https://manpages.ubuntu.com/manpages/kinetic/en/man1/zshparam.1.html
 HISTORY_IGNORE="(cd ..|l[s]#( *)#|pwd *|exit *|date *|* --help)"
@@ -551,13 +551,13 @@ fi
 # having to maintain your own fork.
 
 # Stuff that works on bash or zsh
-if [ -r ~/.sh_aliases ]; then
-  source ~/.sh_aliases
+if [ -r ${ZDOTDIR:-$HOME}/.sh_aliases ]; then
+  source ${ZDOTDIR:-$HOME}/.sh_aliases
 fi
 
 # Stuff only tested on zsh, or explicitly zsh-specific
-if [ -r ~/.zsh_aliases ]; then
-  source ~/.zsh_aliases
+if [ -r ${ZDOTDIR:-$HOME}/.zsh_aliases ]; then
+  source ${ZDOTDIR:-$HOME}/.zsh_aliases
 fi
 
 export LOCATE_PATH=/var/db/locate.database
@@ -575,16 +575,16 @@ fi
 if [[ "$(uname -s)" == "Darwin" ]]; then
   # Load macOS-specific aliases
   # Apple renamed the OS, so use the macos one first
-  [ -r ~/.macos_aliases ] && source ~/.macos_aliases
+  [ -r ${ZDOTDIR:-$HOME}/.macos_aliases ] && source ${ZDOTDIR:-$HOME}/.macos_aliases
   if [ -d ~/.macos_aliases.d ]; then
-    load-shell-fragments ~/.macos_aliases.d
+    load-shell-fragments ${ZDOTDIR:-$HOME}/.macos_aliases.d
   fi
 
   # Keep supporting the old name, but emit a deprecation warning
-  [ -r ~/.osx_aliases ] && source ~/.osx_aliases
+  [ -r ${ZDOTDIR:-$HOME}/.osx_aliases ] && source ${ZDOTDIR:-$HOME}/.osx_aliases
   if [ -d ~/.osx_aliases.d ]; then
     echo "Apple renamed the os to macos - the .osx_aliases.d directory is deprecated in favor of .macos_aliases.d"
-    load-shell-fragments ~/.osx_aliases.d
+    load-shell-fragments ${ZDOTDIR:-$HOME}/.osx_aliases.d
   fi
 fi
 
@@ -630,10 +630,10 @@ if [ -v ls_analog ]; then
 
   # Don't step on system-installed tree command
   if ! can_haz tree; then
-    if [[ -z "$TREE_IGNORE" ]]; then
+    if [[ -z ${TREE_IGNORE-} ]]; then
         TREE_IGNORE=".cache|cache|node_modules|vendor|.git"
     fi
-    alias tree="$ls_analog --tree --ignore-glob='$TREE_IGNORE'"
+    alias tree="$ls_analog --tree --ignore-glob='${TREE_IGNORE-}'"
   fi
   unset ls_analog
 fi
@@ -641,16 +641,16 @@ fi
 # Speed up autocomplete, force prefix mapping
 zstyle ':completion:*' accept-exact '*(N)'
 zstyle ':completion:*' use-cache on
-zstyle ':completion:*' cache-path ~/.zsh/cache
+zstyle ':completion:*' cache-path ${ZDOTDIR:-$HOME}/.zsh/cache
 zstyle -e ':completion:*:default' list-colors 'reply=("${PREFIX:+=(#bi)($PREFIX:t)*==34=34}:${(s.:.)LS_COLORS}")';
 
 # Load any custom zsh completions we've installed
-if [[ -d ~/.zsh-completions.d ]]; then
-  load-shell-fragments ~/.zsh-completions.d
+if [[ -d ${ZDOTDIR:-$HOME}/.zsh-completions.d ]]; then
+  load-shell-fragments ${ZDOTDIR:-$HOME}/.zsh-completions.d
 fi
-if [[ -d ~/.zsh-completions ]]; then
-  echo '~/.zsh_completions is deprecated in favor of ~/.zsh_completions.d'
-  load-shell-fragments ~/.zsh-completions
+if [[ -d ${ZDOTDIR:-$HOME}/.zsh-completions ]]; then
+  echo '${ZDOTDIR:-$HOME}/.zsh_completions is deprecated in favor of ${ZDOTDIR:-$HOME}/.zsh_completions.d'
+  load-shell-fragments ${ZDOTDIR:-$HOME}/.zsh-completions
 fi
 
 # Load zmv
@@ -660,20 +660,20 @@ fi
 
 # Make it easy to append your own customizations that override the
 # quickstart's defaults by loading all files from the ~/.zshrc.d directory
-mkdir -p ~/.zshrc.d
-load-shell-fragments ~/.zshrc.d
+mkdir -p ${ZDOTDIR:-$HOME}/.zshrc.d
+load-shell-fragments ${ZDOTDIR:-$HOME}/.zshrc.d
 
-if [[ -d "$HOME/.zshrc.$(uname).d" ]]; then
-  load-shell-fragments "$HOME/.zshrc.$(uname).d"
+if [[ -d "${ZDOTDIR:-$HOME}/.zshrc.$(uname).d" ]]; then
+  load-shell-fragments "${ZDOTDIR:-$HOME}/.zshrc.$(uname).d"
 fi
 
 # Load work-specific fragments when present
-if [[ -d "$HOME/.zshrc.work.d" ]]; then
-  load-shell-fragments "$HOME/.zshrc.work.d"
+if [[ -d "${ZDOTDIR:-$HOME}/.zshrc.work.d" ]]; then
+  load-shell-fragments "${ZDOTDIR:-$HOME}/.zshrc.work.d"
 fi
 
 # If GOPATH is defined, add it to $PATH
-if [[ -n "$GOPATH" ]]; then
+if [[ -n ${GOPATH-} ]]; then
   if [[ -d "$GOPATH" ]]; then
     export PATH="$PATH:$GOPATH"
   fi
@@ -684,7 +684,7 @@ fi
 typeset -aU path;
 
 # If desk is installed, load the Hook for desk activation
-[[ -n "$DESK_ENV" ]] && source "$DESK_ENV"
+[[ -n ${DESK_ENV-} ]] && source "$DESK_ENV"
 
 # Do selfupdate checking. We do this after processing ~/.zshrc.d to make the
 # refresh check interval easier to customize.
@@ -704,7 +704,7 @@ _load-lastupdate-from-file() {
 }
 
 _update-zsh-quickstart() {
-  local _zshrc_loc=~/.zshrc
+  local _zshrc_loc=${ZDOTDIR:-$HOME}/.zshrc
   if [[ ! -L "${_zshrc_loc}" ]]; then
     echo ".zshrc is not a symlink, skipping zsh-quickstart-kit update"
   else
@@ -732,7 +732,7 @@ _update-zsh-quickstart() {
           fi
           echo "---- updating $zqs_current_branch ----"
           git pull
-          date +%s >! ~/.zsh-quickstart-last-update
+          date +%s >! ${ZDOTDIR:-$HOME}/.zsh-quickstart-last-update
           unset zqs_default_branch
           unset zqs_current_branch
         fi
@@ -746,7 +746,7 @@ _update-zsh-quickstart() {
 _check-for-zsh-quickstart-update() {
   local day_seconds=$(expr 24 \* 60 \* 60)
   local refresh_seconds=$(expr "${day_seconds}" \* "${QUICKSTART_KIT_REFRESH_IN_DAYS}")
-  local last_quickstart_update=$(_load-lastupdate-from-file ~/.zsh-quickstart-last-update)
+  local last_quickstart_update=$(_load-lastupdate-from-file ${ZDOTDIR:-$HOME}/.zsh-quickstart-last-update)
 
   if [ ${last_quickstart_update} -gt ${refresh_seconds} ]; then
     echo "It has been $(expr ${last_quickstart_update} / ${day_seconds}) days since your zsh quickstart kit was updated"
@@ -755,7 +755,7 @@ _check-for-zsh-quickstart-update() {
   fi
 }
 
-if [[ ! -z "$QUICKSTART_KIT_REFRESH_IN_DAYS" ]]; then
+if [[ -n ${QUICKSTART_KIT_REFRESH_IN_DAYS-} ]]; then
   _check-for-zsh-quickstart-update
   # unset QUICKSTART_KIT_REFRESH_IN_DAYS
 fi
@@ -767,11 +767,11 @@ ZSH_AUTOSUGGEST_CLEAR_WIDGETS+=(bracketed-paste)
 # Load iTerm shell integrations if found.
 test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"
 
-# To customize your prompt, run `p10k configure` or edit ~/.p10k.zsh.
-if [[ ! -f ~/.p10k.zsh ]]; then
-  echo "Run p10k configure or edit ~/.p10k.zsh to configure your prompt"
+# To customize your prompt, run `p10k configure` or edit ${ZDOTDIR:-$HOME}/.p10k.zsh.
+if [[ ! -f ${ZDOTDIR:-$HOME}/.p10k.zsh ]]; then
+  echo "Run p10k configure or edit ${ZDOTDIR:-$HOME}/.p10k.zsh to configure your prompt"
 else
-  source ~/.p10k.zsh
+  source ${ZDOTDIR:-$HOME}/.p10k.zsh
 fi
 
 if [[ $(_zqs-get-setting list-ssh-keys true) == 'true' ]]; then
@@ -804,7 +804,7 @@ function zqs-help() {
   echo "The zqs command allows you to manipulate your ZSH quickstart."
   echo
   echo "Quickstart action commands:"
-  echo "zqs check-for-updates - Update the quickstart kit if it has been longer than $QUICKSTART_KIT_REFRESH_IN_DAYS days since the last update."
+  echo "zqs check-for-updates - Update the quickstart kit if it has been longer than ${QUICKSTART_KIT_REFRESH_IN_DAYS-} days since the last update."
   echo "zqs selfupdate - Force an immediate update of the quickstart kit"
   echo "zqs update - Update the quickstart kit and all your plugins"
   echo "zqs update-plugins - Update your plugins"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -49,8 +49,8 @@ fi
 
 # Valid font modes:
 # flat, awesome-patched, awesome-fontconfig, nerdfont-complete, nerdfont-fontconfig
-if [[ -r ~/.powerlevel9k_font_mode ]]; then
-  POWERLEVEL9K_MODE=$(head -1 ~/.powerlevel9k_font_mode)
+if [[ -r ${ZDOTDIR:-$HOME}/.powerlevel9k_font_mode ]]; then
+  POWERLEVEL9K_MODE=$(head -1 ${ZDOTDIR:-$HOME}/.powerlevel9k_font_mode)
 fi
 
 # Unset COMPLETION_WAITING_DOTS in a file in ~/.zshrc.d if you want red dots to be displayed while waiting for completion
@@ -68,8 +68,8 @@ export _ZQS_SETTINGS_DIR
 # them is likely to break things badly.
 
 _zqs-trigger-init-rebuild() {
-  rm -f ~/.zgen/init.zsh
-  rm -f ~/.zgenom/init.zsh
+  rm -f ${ZDOTDIR:-$HOME}/.zgen/init.zsh
+  rm -f ${ZDOTDIR:-$HOME}/.zgenom/init.zsh
 }
 
 # We need to load shell fragment files often enough to make it a function
@@ -178,7 +178,7 @@ function zsh-quickstart-select-bullet-train() {
 }
 
 function zsh-quickstart-select-powerlevel10k() {
-  rm -f ~/.zsh-quickstart-use-bullet-train
+  rm -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-use-bullet-train
   _zqs-set-setting powerlevel10k true
   _zqs-set-setting bullet-train false
   _zqs-trigger-init-rebuild
@@ -223,13 +223,13 @@ function _zqs-disable-zmv-autoloading() {
 }
 
 function zsh-quickstart-disable-omz-plugins() {
-  rm -f ~/.zsh-quickstart-no-omz
+  rm -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-no-omz
   _zqs-set-setting load-omz-plugins false
   _zqs-trigger-init-rebuild
 }
 
 function zsh-quickstart-enable-omz-plugins() {
-  rm -f ~/.zsh-quickstart-no-omz
+  rm -f ${ZDOTDIR:-$HOME}/.zsh-quickstart-no-omz
   _zqs-set-setting load-omz-plugins true
   _zqs-trigger-init-rebuild
 }
@@ -576,13 +576,13 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   # Load macOS-specific aliases
   # Apple renamed the OS, so use the macos one first
   [ -r ${ZDOTDIR:-$HOME}/.macos_aliases ] && source ${ZDOTDIR:-$HOME}/.macos_aliases
-  if [ -d ~/.macos_aliases.d ]; then
+  if [ -d ${ZDOTDIR:-$HOME}/.macos_aliases.d ]; then
     load-shell-fragments ${ZDOTDIR:-$HOME}/.macos_aliases.d
   fi
 
   # Keep supporting the old name, but emit a deprecation warning
   [ -r ${ZDOTDIR:-$HOME}/.osx_aliases ] && source ${ZDOTDIR:-$HOME}/.osx_aliases
-  if [ -d ~/.osx_aliases.d ]; then
+  if [ -d ${ZDOTDIR:-$HOME}/.osx_aliases.d ]; then
     echo "Apple renamed the os to macos - the .osx_aliases.d directory is deprecated in favor of .macos_aliases.d"
     load-shell-fragments ${ZDOTDIR:-$HOME}/.osx_aliases.d
   fi
@@ -908,10 +908,10 @@ function zqs() {
       zqs-quickstart-enable-control-c-decorator
       ;;
     'disable-debug-mode')
-      rm -f ~/.zqs-debug-mode
+      rm -f ${ZDOTDIR:-$HOME}/.zqs-debug-mode
       ;;
     'enable-debug-mode')
-      date > ~/.zqs-debug-mode
+      date > ${ZDOTDIR:-$HOME}/.zqs-debug-mode
       ;;
 
     'disable-diff-so-fancy')
@@ -961,11 +961,11 @@ function zqs() {
     # Profiling checks happen before the settings code is loaded, so we
     # touch the actual file instead of reading via _zqs-get-setting
     'disable-zsh-profiling')
-      rm -f ~/.zqs-zprof-enabled
+      rm -f ${ZDOTDIR:-$HOME}/.zqs-zprof-enabled
       echo "New ZSH sessions will no longer use profiling."
       ;;
     'enable-zsh-profiling')
-      touch ~/.zqs-zprof-enabled
+      touch ${ZDOTDIR:-$HOME}/.zqs-zprof-enabled
       echo "New ZSH sessions will use profiling."
       ;;
     *)
@@ -975,6 +975,6 @@ function zqs() {
   esac
 }
 
-if [[ -f ~/.zqs-zprof-enabled ]]; then
+if [[ -f ${ZDOTDIR:-$HOME}/.zqs-zprof-enabled ]]; then
   zprof
 fi


### PR DESCRIPTION
# PR: Make zsh-quickstart-kit ZDOTDIR-aware and nounset-resilient

This change makes core zsh-quickstart-kit files work seamlessly when users set ZDOTDIR to a custom configuration directory, and hardens them against `setopt nounset` (error on unset parameters).

## Summary of changes

Files modified:
- zsh/.zshrc
  - Replace hardcoded `~/...` paths to zsh config files with `${ZDOTDIR:-$HOME}/...`
  - Guard variable tests with nounset-safe expansions (`${VAR-}`, `${VAR:-default}`, `(( ${+VAR} ))`)
  - Examples:
    - `~/.zqs-zprof-enabled`, `~/.zqs-debug-mode`, `~/.zqs-settings-path`, `~/.zqs-settings`
    - `~/.zshrc.pre-plugins.d`, `~/.zshrc.add-plugins.d`, `~/.zshrc.d`, `~/.zshrc.$(uname).d`, `~/.zshrc.work.d`
    - `~/.zgen-setup`, `~/.zsh_functions`, `~/.zsh_aliases`, `~/.sh_aliases`
    - `~/.zsh/completions` cache path, `~/.zsh-completions(.d)`
    - `~/.macos_aliases(.d)`, `~/.osx_aliases(.d)`
    - `~/.zsh_history`, `~/.zsh-quickstart-last-update`, `~/.p10k.zsh`
  - Nounset fixes in common tests:
    - `[[ -z "$LSCOLORS" ]]` -> `[[ -z ${LSCOLORS-} ]]`
    - `[[ -z "$SSH_CLIENT" ]]` -> `[[ -z ${SSH_CLIENT-} ]]`
    - `[[ -z "$GENCOMPL_PY" ]]` -> `[[ -z ${GENCOMPL_PY-} ]]`
    - `[[ -n "$ZSH_COMPLETION_HACK" ]]` -> `[[ -n ${ZSH_COMPLETION_HACK-} ]]`
    - `[[ -z "$TREE_IGNORE" ]]` -> `[[ -z ${TREE_IGNORE-} ]]`
    - `[[ -n "$GOPATH" ]]` -> `[[ -n ${GOPATH-} ]]`
    - `[[ -n "$DESK_ENV" ]]` -> `[[ -n ${DESK_ENV-} ]]`
  - Function `load-shell-fragments` now guards `$1` with `${1-}` and properly quotes paths
- zsh/.zgen-setup
  - Default zgenom parent and data dir honor ZDOTDIR: `ZGEN_DIR=${ZGEN_DIR:-${ZDOTDIR:-$HOME}/.zgenom}`
  - Use `${ZDOTDIR:-$HOME}` for prompt change marker, additional-plugins, OMZ gating, plugin directories, and zgen init timestamps
  - Respect ZDOTDIR for local overrides: `.zgen-local-plugins`, `.zsh-quickstart-local-plugins`
  - Use ZDOTDIR-relative GENCOMPL_FPATH (`${ZDOTDIR:-$HOME}/.zsh/complete`)
  - Nounset-safe tests for `need_update`
- zsh/.zsh_aliases
  - Only set VISUAL if EDITOR is set (nounset-safe):
    - `if (( ${+EDITOR} )); then export VISUAL="$EDITOR"; fi`
  - Source `${ZDOTDIR:-$HOME}/.zsh_aliases.local` instead of `~/.zsh_aliases.local`
- zsh/.zsh_functions
  - Source `${ZDOTDIR:-$HOME}/.zsh_functions.local` instead of `~/.zsh_functions.local`

Behavior when ZDOTDIR is unset remains identical because `${ZDOTDIR:-$HOME}` falls back to `$HOME`.

## Rationale
- ZDOTDIR-awareness enables portable configs in non-standard locations (e.g., `$XDG_CONFIG_HOME/zsh`)
- Nounset-resilience prevents startup failures under strict shells (setopt UNSET)
- Backwards compatibility maintained via defaulting to `$HOME` when ZDOTDIR is unset

## How to test

Test matrix:
- A) ZDOTDIR set to custom dir
- B) ZDOTDIR unset (default `$HOME`)

Common setup:
- Ensure your `.zshrc` is a symlink to the kit’s `zsh/.zshrc` (as recommended by zqs docs)

A) ZDOTDIR set
- Run fresh interactive shells twice (first run regenerates caches, second uses caches):
  - `ZDOTDIR="$HOME/dotfiles/dot-config/zsh" ZSH_FORCE_ZGEN_RESET=1 zsh -i -c exit`
  - `ZDOTDIR="$HOME/dotfiles/dot-config/zsh" zsh -i -c exit`
- Verify:
  - No `parameter not set` errors
  - Plugins load; prompt renders; history file at `${ZDOTDIR}/.zsh_history`
  - Completion cache at `${ZDOTDIR}/.zsh/cache`
  - `.zgenom/init.zsh` created under `${ZDOTDIR}/.zgenom/`

B) ZDOTDIR unset
- Run from a login/interactive shell with default `$HOME`:
  - `env -u ZDOTDIR ZSH_FORCE_ZGEN_RESET=1 zsh -i -c exit`
  - `env -u ZDOTDIR zsh -i -c exit`
- Verify same outcomes, but paths under `$HOME` instead of `${ZDOTDIR}`

Smoke checks in both scenarios:
- `zqs update-plugins` (via zgenom)
- `zqs check-for-updates` (last-update stamp is at `${ZDOTDIR}/.zsh-quickstart-last-update`)
- Toggle `~/.zqs-zprof-enabled` in the active ZDOTDIR and confirm zprof loads/suppresses

## Suggested branch name and commit message
- Branch: `fix/zdotdir-nounset-resilience`
- Commit message:
  - Title: `Make zsh-quickstart-kit ZDOTDIR-aware and nounset-resilient`
  - Body:
    - "Replace hardcoded HOME paths for zsh config with ${ZDOTDIR:-$HOME} and add nounset-safe guards (${VAR-}, ${VAR:-default}, (( ${+VAR} ))). No behavior change when ZDOTDIR is unset."

## Open the PR upstream

From the kit checkout directory (the repo that contains `zsh/.zshrc`):

1) Create branch and commit
- `git checkout -b fix/zdotdir-nounset-resilience`
- `git add zsh/.zshrc zsh/.zgen-setup zsh/.zsh_aliases zsh/.zsh_functions`
- `git commit -m "Make zsh-quickstart-kit ZDOTDIR-aware and nounset-resilient\n\n- Use \${ZDOTDIR:-$HOME} for config paths\n- Guard unset vars with \${VAR-}/\${VAR:-default}/(( \${+VAR} ))\n- Preserve behavior when ZDOTDIR unset"`

2) Fork and add remote (if not already)
- `gh repo fork --remote --remote-name fork`

3) Push branch
- `git push -u fork fix/zdotdir-nounset-resilience`

4) Create PR
- `gh pr create --base main --head <your-user>:fix/zdotdir-nounset-resilience \
  --title "Make zsh-quickstart-kit ZDOTDIR-aware and nounset-resilient" \
  --body "See description and test plan in the PR. Maintains backward compatibility when ZDOTDIR is unset."`

Manual alternative:
- Open: `https://github.com/unixorn/zsh-quickstart-kit/compare/main...<your-user>:fix/zdotdir-nounset-resilience?expand=1`

## Notes
- Only zsh-configuration-related paths were made ZDOTDIR-aware; non-zsh data (e.g., `~/.ssh`, `~/.aws`) intentionally left under `$HOME`.
- Where feasible, messages mentioning paths were updated to reflect ZDOTDIR usage.

