### PR TITLE
Add fzf-tab plugin and gitignore .zshrc.d directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 # dc = don't commit
 *.dc.*
 *.log
+
+# It is necessary for the update to work correctly, if there are added scripts.
+zsh/.zshrc.d
+!zsh/.zshrc.d/001-load-mise-if-present

--- a/.zsh-quickstart-local-plugins-example
+++ b/.zsh-quickstart-local-plugins-example
@@ -47,6 +47,8 @@ warn-about-prompt-change() {
 # as a starting point. This keeps you from having to maintain a fork of
 # the quickstart kit.
 
+zgenom load Aloxaf/fzf-tab
+
 # If zsh-syntax-highlighting is bundled after zsh-history-substring-search,
 # they break, so get the order right.
 zgenom load zdharma-continuum/fast-syntax-highlighting

--- a/zsh/.zgen-setup
+++ b/zsh/.zgen-setup
@@ -77,6 +77,8 @@ load-starter-plugin-list() {
   # copy as a starting point. This keeps you from having to maintain a fork of
   # the quickstart kit.
 
+  zgenom load Aloxaf/fzf-tab
+
   # If zsh-syntax-highlighting is bundled after zsh-history-substring-search,
   # they break, so get the order right.
   zgenom load zdharma-continuum/fast-syntax-highlighting


### PR DESCRIPTION
# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

## Description

- **Load `Aloxaf/fzf-tab`** in the zgen plugin list — replaces zsh's default tab-completion menu with an fzf-powered one when [fzf](https://github.com/junegunn/fzf) is installed, giving a much nicer completion UX.
- **Ignore `zsh/.zshrc.d`** in `.gitignore`, except `001-load-mise-if-present`. This keeps user-local scripts from leaking into the repo while keeping the bundled mise loader tracked, and is needed for the update flow to work correctly when there are added scripts.

## Type of changes

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [ ] Bug fix
- [ ] New feature
- [x] Plugin list change

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the readme if this PR changes/updates quickstart functionality.
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have added a credit line to README.md for the script
- [x] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.